### PR TITLE
Build info endpoint

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -38,6 +38,8 @@ const paths = {
         "src/js/base/utils.js",
         "src/js/base/api.js",
         "src/js/base/auth.js",
+        "src/js/api/account.js",
+        "src/js/api/admin.js",
         "src/js/api/brand.js",
         "src/js/api/build.js",
         "src/js/api/config.js",

--- a/src/js/api/admin.js
+++ b/src/js/api/admin.js
@@ -1,6 +1,9 @@
 if (
     typeof require !== "undefined" &&
-    (typeof window === "undefined" || typeof __webpack_require__ !== "undefined") // eslint-disable-line camelcase
+    (typeof window === "undefined" ||
+        // eslint-disable-next-line camelcase
+        typeof __webpack_require__ !== "undefined" ||
+        (navigator !== undefined && navigator.product === "ReactNative"))
 ) {
     // eslint-disable-next-line no-redeclare
     var base = require("../base");
@@ -9,14 +12,14 @@ if (
 }
 
 /**
- * Retrieves the build information by brand name and version.
+ * Retrieves the build artifact information by brand name and version.
  *
- * @param {String} name The name of the brand of the build.
- * @param {Number} version The number of the version of the build.
+ * @param {String} name The name of the brand of the build artifact.
+ * @param {Number} version The number of the version of the build artifact.
  * @param {Object} options An object of options to configure the request.
  * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
  */
-ripe.Ripe.prototype.getBuildAdmin = function(name, version, options, callback) {
+ripe.Ripe.prototype.getBuildArtifactAdmin = function(name, version, options, callback) {
     callback = typeof options === "function" ? options : callback;
     options = typeof options === "function" || options === undefined ? {} : options;
     const url = `${this.webUrl}admin/builds/${name}/artifacts/${version}`;
@@ -30,14 +33,14 @@ ripe.Ripe.prototype.getBuildAdmin = function(name, version, options, callback) {
 };
 
 /**
- * Retrieves the build information by brand name and version.
+ * Retrieves the build artifact information by brand name and version.
  *
- * @param {String} name The name of the brand of the build.
- * @param {Number} version The number of the version of the build.
+ * @param {String} name The name of the brand of the build artifact.
+ * @param {Number} version The number of the version of the build artifact.
  * @param {Object} options An object of options to configure the request.
  * @returns {Promise} The build result (as a promise).
  */
-ripe.Ripe.prototype.getBuildAdminP = function(name, version, options) {
+ripe.Ripe.prototype.getBuildArtifactAdminP = function(name, version, options) {
     return new Promise((resolve, reject) => {
         this.getBuild(name, version, options, (result, isValid, request) => {
             isValid ? resolve(result) : reject(new ripe.RemoteError(request));

--- a/src/js/api/admin.js
+++ b/src/js/api/admin.js
@@ -1,0 +1,46 @@
+if (
+    typeof require !== "undefined" &&
+    (typeof window === "undefined" || typeof __webpack_require__ !== "undefined") // eslint-disable-line camelcase
+) {
+    // eslint-disable-next-line no-redeclare
+    var base = require("../base");
+    // eslint-disable-next-line no-redeclare
+    var ripe = base.ripe;
+}
+
+/**
+ * Retrieves the build information by brand name and version.
+ *
+ * @param {String} name The name of the brand of the build.
+ * @param {Number} version The number of the version of the build.
+ * @param {Object} options An object of options to configure the request.
+ * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
+ */
+ripe.Ripe.prototype.getBuildAdmin = function(name, version, options, callback) {
+    callback = typeof options === "function" ? options : callback;
+    options = typeof options === "function" || options === undefined ? {} : options;
+    const url = `${this.webUrl}admin/builds/${name}/artifacts/${version}`;
+    options = {
+        url: url,
+        method: "GET",
+        auth: true
+    };
+    options = this._build(options);
+    return this._cacheURL(options.url, options, callback);
+};
+
+/**
+ * Retrieves the build information by brand name and version.
+ *
+ * @param {String} name The name of the brand of the build.
+ * @param {Number} version The number of the version of the build.
+ * @param {Object} options An object of options to configure the request.
+ * @returns {Promise} The build result (as a promise).
+ */
+ripe.Ripe.prototype.getBuildAdminP = function(name, version, options) {
+    return new Promise((resolve, reject) => {
+        this.getBuild(name, version, options, (result, isValid, request) => {
+            isValid ? resolve(result) : reject(new ripe.RemoteError(request));
+        });
+    });
+};

--- a/src/js/api/build.js
+++ b/src/js/api/build.js
@@ -9,38 +9,6 @@ if (
 }
 
 /**
- * Gets a build by brand name and version.
- *
- * @param {String} name The name of the brand of the build.
- * @param {Number} version The number of the version of the build.
- * @param {Object} options An object of options to configure the request.
- * @returns {Promise} The build result.
- */
-ripe.Ripe.prototype.getBuildP = function(name, version, options) {
-    return new Promise((resolve, reject) => {
-        this.getBuild(name, version, options, (result, isValid, request) => {
-            isValid ? resolve(result) : reject(new ripe.RemoteError(request));
-        });
-    });
-};
-
-/**
- * @ignore
- */
-ripe.Ripe.prototype.getBuild = function(name, version, options, callback) {
-    callback = typeof options === "function" ? options : callback;
-    options = typeof options === "function" || options === undefined ? {} : options;
-    const url = `${this.webUrl}admin/builds/${name}/artifacts/${version}`;
-    options = {
-        url: url,
-        method: "GET",
-        auth: true
-    };
-    options = this._build(options);
-    return this._cacheURL(options.url, options, callback);
-};
-
-/**
  * Retrieves the bundle of part, materials and colors translations of a specific brand and model
  * If no model is defined the retrieves the bundle of the owner's current model.
  *

--- a/src/js/api/build.js
+++ b/src/js/api/build.js
@@ -9,6 +9,38 @@ if (
 }
 
 /**
+ * Gets a build by brand name and version.
+ *
+ * @param {String} name The name of the brand of the build.
+ * @param {Number} version The number of the version of the build.
+ * @param {Object} options An object of options to configure the request.
+ * @returns {Promise} The build result.
+ */
+ripe.Ripe.prototype.getBuildP = function(name, version, options) {
+    return new Promise((resolve, reject) => {
+        this.getBuild(name, version, options, (result, isValid, request) => {
+            isValid ? resolve(result) : reject(new ripe.RemoteError(request));
+        });
+    });
+};
+
+/**
+ * @ignore
+ */
+ripe.Ripe.prototype.getBuild = function(name, version, options, callback) {
+    callback = typeof options === "function" ? options : callback;
+    options = typeof options === "function" || options === undefined ? {} : options;
+    const url = `${this.webUrl}admin/builds/${name}/artifacts/${version}`;
+    options = {
+        url: url,
+        method: "GET",
+        auth: true
+    };
+    options = this._build(options);
+    return this._cacheURL(options.url, options, callback);
+};
+
+/**
  * Retrieves the bundle of part, materials and colors translations of a specific brand and model
  * If no model is defined the retrieves the bundle of the owner's current model.
  *

--- a/src/js/api/index.js
+++ b/src/js/api/index.js
@@ -1,4 +1,5 @@
 const account = require("./account");
+const admin = require("./admin");
 const brand = require("./brand");
 const build = require("./build");
 const config = require("./config");
@@ -12,6 +13,7 @@ const size = require("./size");
 const sku = require("./sku");
 
 Object.assign(module.exports, account);
+Object.assign(module.exports, admin);
 Object.assign(module.exports, brand);
 Object.assign(module.exports, build);
 Object.assign(module.exports, config);


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/127 |
| Decisions | SDK support for new ripe-core endpoint that returns information about a specific build, given the brand name and build version. [PR ripe-core](https://github.com/ripe-tech/ripe-core/pull/4433)|