### PR TITLE
#178: New events for loading time

### DIFF
--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -586,6 +586,8 @@ ripe.Ripe.prototype.setInitials = async function(initials, engraving, events = t
         return result;
     }
 
+    // triggers the event indicating the the start of the
+    // the (set) initials operation (notifies listeners)
     this.trigger("pre_initials");
 
     // sets the base instance fields for both the initials and the
@@ -617,6 +619,8 @@ ripe.Ripe.prototype.setInitials = async function(initials, engraving, events = t
     // components can properly update their visuals
     this.update();
 
+    // triggers the event indicating the the end of the
+    // the (set) initials operation (notifies listeners)
     this.trigger("post_initials");
 
     // returns the current instance (good for pipelining)
@@ -638,6 +642,8 @@ ripe.Ripe.prototype.setInitialsExtra = async function(initialsExtra, events = tr
     const mainGroup = groups.includes("main") ? "main" : groups[0];
     const mainInitials = initialsExtra[mainGroup];
 
+    // triggers the event indicating the the start of the
+    // the (set) initials extra operation (notifies listeners)
     this.trigger("pre_initials_extra");
 
     if (isEmpty) {
@@ -670,6 +676,8 @@ ripe.Ripe.prototype.setInitialsExtra = async function(initialsExtra, events = tr
     // components can properly update their visuals
     this.update();
 
+    // triggers the event indicating the the end of the
+    // the (set) initials extra operation (notifies listeners)
     this.trigger("post_initials_extra");
 
     // returns the current instance (good for pipelining)

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -586,6 +586,8 @@ ripe.Ripe.prototype.setInitials = async function(initials, engraving, events = t
         return result;
     }
 
+    this.trigger("pre_initials");
+
     // sets the base instance fields for both the initials and the
     // engraving and updates the initials extra on the main group,
     // providing a compatibility layer between the initials and the
@@ -615,6 +617,8 @@ ripe.Ripe.prototype.setInitials = async function(initials, engraving, events = t
     // components can properly update their visuals
     this.update();
 
+    this.trigger("post_initials");
+
     // returns the current instance (good for pipelining)
     return this;
 };
@@ -633,6 +637,8 @@ ripe.Ripe.prototype.setInitialsExtra = async function(initialsExtra, events = tr
     const isEmpty = groups.length === 0;
     const mainGroup = groups.includes("main") ? "main" : groups[0];
     const mainInitials = initialsExtra[mainGroup];
+
+    this.trigger("pre_initials_extra");
 
     if (isEmpty) {
         this.initials = "";
@@ -663,6 +669,8 @@ ripe.Ripe.prototype.setInitialsExtra = async function(initialsExtra, events = tr
     // runs the update operation so that all the listening
     // components can properly update their visuals
     this.update();
+
+    this.trigger("post_initials_extra");
 
     // returns the current instance (good for pipelining)
     return this;

--- a/src/js/visual/configurator.js
+++ b/src/js/visual/configurator.js
@@ -200,6 +200,7 @@ ripe.Configurator.prototype.update = async function(state, options = {}) {
     previous = this.unique;
     const unique = signature + "&view=" + String(view) + "&position=" + String(position);
     if (previous === unique && !force) {
+        this.trigger("not_loaded");
         return false;
     }
     this.unique = unique;

--- a/src/js/visual/configurator.js
+++ b/src/js/visual/configurator.js
@@ -165,7 +165,8 @@ ripe.Configurator.prototype.resize = function(size) {
  */
 ripe.Configurator.prototype.update = async function(state, options = {}) {
     if (this.ready === false) {
-        return;
+        this.trigger("not_loaded");
+        return false;
     }
 
     const view = this.element.dataset.view;
@@ -225,6 +226,10 @@ ripe.Configurator.prototype.update = async function(state, options = {}) {
         animate: animate,
         duration: duration
     });
+
+    // returns a valid value indicating that the loading operation
+    // as been triggered with success (effective operation)
+    return true;
 };
 
 /**

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -113,6 +113,7 @@ ripe.Image.prototype.update = async function(state, options = {}) {
     // verifies if the target image URL for the update is already
     // set and if that's the case returns (end of loop)
     if (this.element.src === url) {
+        this.trigger("not_loaded");
         return;
     }
 

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -94,7 +94,8 @@ ripe.Image.prototype.update = async function(state, options = {}) {
     // render the frame to be display and if that's not the case "ignores"
     // the current request for update
     if (frame && !this.owner.hasFrame(frame)) {
-        return;
+        this.trigger("not_loaded");
+        return false;
     }
 
     // builds the URL of the image using the frame hacking approach
@@ -114,7 +115,7 @@ ripe.Image.prototype.update = async function(state, options = {}) {
     // set and if that's the case returns (end of loop)
     if (this.element.src === url) {
         this.trigger("not_loaded");
-        return;
+        return false;
     }
 
     // updates the image DOM element with the values of the image
@@ -126,6 +127,10 @@ ripe.Image.prototype.update = async function(state, options = {}) {
         this.element.height = height;
     }
     this.element.src = url;
+
+    // returns a valid value indicating that the loading operation
+    // as been triggered with success (effective operation)
+    return true;
 };
 
 /**


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/178 |
| Decisions | Added `pre_initials`, `post_initials`, `pre_initials_extra`, `post_initials_extra` and `not_loaded`events. The last 2 ones are for images and configurators that receive an update request but don't load a new image. |
| Animated GIF | - |
