### PR TITLE
Fix mask error handler

### DIFF
--- a/src/js/visual/configurator.js
+++ b/src/js/visual/configurator.js
@@ -606,7 +606,7 @@ ripe.Configurator.prototype.highlight = function(part, options = {}) {
         self.trigger("highlighted_part", part);
     };
     this.frontMaskError = function() {
-        frontMask.setAttribute("src", "");
+        this.setAttribute("src", "");
     };
     frontMask.addEventListener("load", this.frontMaskLoad);
     frontMask.addEventListener("error", this.frontMaskError);

--- a/src/js/visual/configurator.js
+++ b/src/js/visual/configurator.js
@@ -606,7 +606,7 @@ ripe.Configurator.prototype.highlight = function(part, options = {}) {
         self.trigger("highlighted_part", part);
     };
     this.frontMaskError = function() {
-        self.setAttribute("src", "");
+        frontMask.setAttribute("src", "");
     };
     frontMask.addEventListener("load", this.frontMaskLoad);
     frontMask.addEventListener("error", this.frontMaskError);


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | `setAttribute` was supposed to clean the `src` on the mask `<img>` that triggered the error, but was called on `self` which doesn't even define such a method. |
