### PR TITLE
#341 Fixes hanging white, when removing "Image"

### DIFF
--- a/src/js/base/interactable.js
+++ b/src/js/base/interactable.js
@@ -57,7 +57,7 @@ ripe.Interactable.prototype.update = async function(state, options = {}) {};
  * it should stop responding to updates so that any necessary
  * cleanup operations can be executed.
  */
-ripe.Interactable.prototype.deinit = function() {
+ripe.Interactable.prototype.deinit = async function() {
     this.owner = null;
 
     ripe.Observable.prototype.deinit.call(this);

--- a/src/js/base/observable.js
+++ b/src/js/base/observable.js
@@ -102,7 +102,7 @@ ripe.Observable.prototype.runCallbackNoWait = async function(event, ...args) {
  * The deinitializer of the class, called whenever this
  * observable ceases its activity.
  */
-ripe.Observable.prototype.deinit = function() {
+ripe.Observable.prototype.deinit = async function() {
     this.callbacks = null;
 };
 

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -247,7 +247,7 @@ ripe.Ripe.prototype.deinit = async function() {
 
     for (index = this.children.length - 1; index >= 0; index--) {
         const child = this.children[index];
-        this.unbindInteractable(child);
+        await this.unbindInteractable(child);
     }
 
     for (index = this.plugins.length - 1; index >= 0; index--) {
@@ -1015,8 +1015,8 @@ ripe.Ripe.prototype.bindInteractable = function(element) {
  * @param {Interactable} element The Interactable instance to be unbound.
  * @returns {Interactable} Returns the unbounded Interactable.
  */
-ripe.Ripe.prototype.unbindInteractable = function(element) {
-    element.deinit();
+ripe.Ripe.prototype.unbindInteractable = async function(element) {
+    await element.deinit();
     this.children.splice(this.children.indexOf(element), 1);
     this.trigger("unbound", element);
 };

--- a/src/js/visual/configurator.js
+++ b/src/js/visual/configurator.js
@@ -275,6 +275,8 @@ ripe.Configurator.prototype.cancel = async function(options = {}) {
  * cleanup operations can be executed.
  */
 ripe.Configurator.prototype.deinit = async function() {
+    await this.cancel();
+
     while (this.element.firstChild) {
         this.element.removeChild(this.element.firstChild);
     }

--- a/src/js/visual/configurator.js
+++ b/src/js/visual/configurator.js
@@ -274,7 +274,7 @@ ripe.Configurator.prototype.cancel = async function(options = {}) {
  * it should stop responding to updates so that any necessary
  * cleanup operations can be executed.
  */
-ripe.Configurator.prototype.deinit = function() {
+ripe.Configurator.prototype.deinit = async function() {
     while (this.element.firstChild) {
         this.element.removeChild(this.element.firstChild);
     }

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -195,7 +195,8 @@ ripe.Image.prototype.cancel = async function(options = {}) {
  * it should stop responding to updates so that any necessary
  * cleanup operations can be executed.
  */
-ripe.Image.prototype.deinit = function() {
+ripe.Image.prototype.deinit = async function() {
+    await this.cancel();
     this._unregisterHandlers();
     this._observer = null;
     this.initialsBuilder = null;
@@ -269,7 +270,6 @@ ripe.Image.prototype._registerHandlers = function() {
 ripe.Image.prototype._unregisterHandlers = function() {
     if (this.loadListener) this.element.removeEventListener("load", this.loadListener);
     if (this.errorListener) this.element.removeEventListener("error", this.errorListener);
-    if (this._loadedCallback) this._loadedCallback({ canceled: true });
     if (this.loadedHandler) this.unbind("loaded", this.loadedHandler);
     if (this.errorHandler) this.unbind("error", this.errorHandler);
     if (this._observer) this._observer.disconnect();

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -269,6 +269,7 @@ ripe.Image.prototype._registerHandlers = function() {
 ripe.Image.prototype._unregisterHandlers = function() {
     if (this.loadListener) this.element.removeEventListener("load", this.loadListener);
     if (this.errorListener) this.element.removeEventListener("error", this.errorListener);
+    if (this._loadedCallback) this._loadedCallback({ canceled: true });
     if (this.loadedHandler) this.unbind("loaded", this.loadedHandler);
     if (this.errorHandler) this.unbind("error", this.errorHandler);
     if (this._observer) this._observer.disconnect();

--- a/src/js/visual/visual.js
+++ b/src/js/visual/visual.js
@@ -56,7 +56,7 @@ ripe.Visual.prototype.init = function() {
  * it should stop responding to updates so that any necessary
  * cleanup operations can be executed.
  */
-ripe.Visual.prototype.deinit = function() {
+ripe.Visual.prototype.deinit = async function() {
     this._removeElementHandlers();
     this.element = null;
     this.elementEvents = null;

--- a/src/python/ripe_demo/static/js/main.js
+++ b/src/python/ripe_demo/static/js/main.js
@@ -4,7 +4,7 @@
  */
 var FACES = ["side", "top", "front"];
 
-window.onload = function() {
+window.onload = function () {
     var element = document.getElementById("configurator");
     var _body = document.querySelector("body");
     var url = _body.dataset.url || "https://sandbox.platforme.com/api/";
@@ -35,7 +35,7 @@ window.onload = function() {
         guessUrl: guessUrl
     });
 
-    var randomize = async function() {
+    var randomize = async function () {
         var parts = [];
         for (var key in partsMap) {
             var triplets = partsMap[key];
@@ -46,7 +46,7 @@ window.onload = function() {
         await ripe.setParts(parts, true, { partEvents: false });
     };
 
-    var unique = function() {
+    var unique = function () {
         var count = 1;
         for (var key in partsMap) {
             var triplets = partsMap[key];
@@ -55,7 +55,7 @@ window.onload = function() {
         return count;
     };
 
-    var beautify = function(value) {
+    var beautify = function (value) {
         var buffer = [];
         var parts = value.split("_");
         for (var index = 0; index < parts.length; index++) {
@@ -65,7 +65,7 @@ window.onload = function() {
         return buffer.join(" ");
     };
 
-    var bestFace = function(config) {
+    var bestFace = function (config) {
         var faces = config.faces || [];
         var bestFace = null;
         for (var index = 0; index < FACES.length; index++) {
@@ -82,7 +82,7 @@ window.onload = function() {
         return faces.length > 0 ? faces[0] : null;
     };
 
-    var init = function(instance) {
+    var init = function (instance) {
         initBase(instance);
         initHeader(instance);
         initOAuth(instance);
@@ -90,10 +90,10 @@ window.onload = function() {
         initInitials(instance);
     };
 
-    var initBase = function() {
+    var initBase = function () {
         // registers for the key down event on the global document element
         // to listen to some of the key strokes (global operations)
-        document.addEventListener("keydown", async function(event) {
+        document.addEventListener("keydown", async function (event) {
             if (event.ctrlKey && event.keyCode === 90) {
                 await ripe.undo();
             }
@@ -104,25 +104,25 @@ window.onload = function() {
         });
     };
 
-    var initHeader = function() {
+    var initHeader = function () {
         var setPart = document.getElementById("set-part");
         var setMessage = document.getElementById("set-message");
         var getPrice = document.getElementById("get-price");
         var getCombinations = document.getElementById("get-combinations");
 
         setPart &&
-            setPart.addEventListener("click", function() {
+            setPart.addEventListener("click", function () {
                 randomize();
             });
 
         setMessage &&
-            setMessage.addEventListener("click", function() {
+            setMessage.addEventListener("click", function () {
                 alert("Not implemented");
             });
 
         getPrice &&
-            getPrice.addEventListener("click", function() {
-                ripe.getPrice(function(value) {
+            getPrice.addEventListener("click", function () {
+                ripe.getPrice(function (value) {
                     if (value) {
                         alert(String(value.total.price_final) + " " + value.total.currency);
                     } else {
@@ -132,8 +132,8 @@ window.onload = function() {
             });
 
         getCombinations &&
-            getCombinations.addEventListener("click", function() {
-                ripe.getCombinations(function(combinations) {
+            getCombinations.addEventListener("click", function () {
+                ripe.getCombinations(function (combinations) {
                     alert(
                         "There are <strong>" +
                             String(combinations.length.formatMoney(0)) +
@@ -144,15 +144,15 @@ window.onload = function() {
                 });
             });
 
-        ripe.bind("error", function(error, description) {
+        ripe.bind("error", function (error, description) {
             alert(error);
         });
 
-        ripe.bind("message", function(name, value) {
+        ripe.bind("message", function (name, value) {
             alert(name + " - " + value);
         });
 
-        ripe.bind("price", function(value) {
+        ripe.bind("price", function (value) {
             var price = document.getElementById("price");
             if (!value || !value.total) {
                 price.innerHTML = "N/A";
@@ -161,7 +161,7 @@ window.onload = function() {
             price.innerHTML = value.total.price_final + " " + value.total.currency;
         });
 
-        ripe.bind("combinations", function(value) {
+        ripe.bind("combinations", function (value) {
             for (var index = 0; index < value.length; index++) {
                 var triplet = value[index];
                 var part = triplet[0];
@@ -173,13 +173,13 @@ window.onload = function() {
         });
     };
 
-    var initOAuth = function() {
+    var initOAuth = function () {
         let oauthLogin = document.getElementById("oauth-login");
         let oauthLogout = document.getElementById("oauth-logout");
         let oauthOperation = document.getElementById("oauth-operation");
 
         oauthLogin &&
-            oauthLogin.addEventListener("click", function() {
+            oauthLogin.addEventListener("click", function () {
                 ripe.oauth({
                     clientId: clientId,
                     clientSecret: clientSecret,
@@ -189,13 +189,13 @@ window.onload = function() {
             });
 
         oauthLogout &&
-            oauthLogout.addEventListener("click", function() {
+            oauthLogout.addEventListener("click", function () {
                 ripe.unauth();
             });
 
         oauthOperation &&
-            oauthOperation.addEventListener("click", function() {
-                ripe.getOrders(function(result) {
+            oauthOperation.addEventListener("click", function () {
+                ripe.getOrders(function (result) {
                     alert("Retrieved " + String(result.length) + " orders");
                 });
             });
@@ -208,13 +208,13 @@ window.onload = function() {
         oauthLogout = oauthLogout || { style: {} };
         oauthOperation = oauthOperation || { style: {} };
 
-        ripe.bind("auth", function() {
+        ripe.bind("auth", function () {
             oauthLogin.style.display = "none";
             oauthLogout.style.display = "block";
             oauthOperation.style.display = "block";
         });
 
-        ripe.bind("unauth", function() {
+        ripe.bind("unauth", function () {
             oauthLogin.style.display = "block";
             oauthLogout.style.display = "none";
             oauthOperation.style.display = "none";
@@ -225,16 +225,16 @@ window.onload = function() {
         oauthOperation.style.display = "none";
     };
 
-    var initConfigurator = function() {
+    var initConfigurator = function () {
         // loads the config of the product to retrieve the
         // complete configuration of the product and be able
         // to define the visible frames and apply restrictions
         var caller = ripe.loadedConfig
-            ? function(callback) {
+            ? function (callback) {
                   callback(ripe.loadedConfig);
               }
             : ripe.getConfig;
-        caller(function(result) {
+        caller(function (result) {
             var frame0 = document.getElementById("frame-0");
             var frame6 = document.getElementById("frame-6");
             var frameTop = document.getElementById("frame-top");
@@ -275,7 +275,7 @@ window.onload = function() {
                 });
             }
 
-            frame0.addEventListener("click", function() {
+            frame0.addEventListener("click", function () {
                 if (result.frames > 9) {
                     configurator.changeFrame("side-9", {
                         revolutionDuration: 500
@@ -286,28 +286,28 @@ window.onload = function() {
                     });
                 }
             });
-            frame6.addEventListener("click", function() {
+            frame6.addEventListener("click", function () {
                 configurator.changeFrame("side-6", {
                     revolutionDuration: 500
                 });
             });
-            frameTop.addEventListener("click", function() {
+            frameTop.addEventListener("click", function () {
                 configurator.changeFrame("top-0", {
                     duration: 250
                 });
             });
-            frameFront.addEventListener("click", function() {
+            frameFront.addEventListener("click", function () {
                 configurator.changeFrame("front-0", {
                     duration: 250
                 });
             });
 
             image &&
-                image.bind("loaded", function() {
+                image.bind("loaded", function () {
                     console.log("frame-0 loaded");
                 });
 
-            setTimeout(function() {
+            setTimeout(function () {
                 if (result.frames > 9) {
                     image && image.setFrame("side-9");
                 }
@@ -320,7 +320,7 @@ window.onload = function() {
             });
             configurator.isFirst = true;
 
-            configurator.bind("loaded", function() {
+            configurator.bind("loaded", function () {
                 if (configurator.isFirst) configurator.isFirst = false;
                 else return;
                 if (result.faces.indexOf("side") !== -1) {
@@ -343,26 +343,26 @@ window.onload = function() {
         });
     };
 
-    var initInitials = function() {
+    var initInitials = function () {
         ripe.bindImage(document.getElementById("initials"), {
             showInitials: true
         });
 
-        ripe.bind("initials_extra", function(initialsExtra) {
+        ripe.bind("initials_extra", function (initialsExtra) {
             document.getElementById("initials-text").value =
                 initialsExtra.main && initialsExtra.main.initials
                     ? initialsExtra.main.initials
                     : "";
         });
 
-        document.getElementById("initials-text").addEventListener("keyup", function() {
+        document.getElementById("initials-text").addEventListener("keyup", function () {
             var initialsDrop = document.getElementById("initials-drop");
             var initialsDropContainer = initialsDrop.parentElement;
             var initialsInput = initialsDropContainer.getElementsByTagName("input")[0];
             ripe.setInitials(this.value, initialsInput.value);
         });
 
-        document.getElementById("initials-drop").onvalue_change = function() {
+        document.getElementById("initials-drop").onvalue_change = function () {
             var initialsText = document.getElementById("initials-text");
             var initialsDropContainer = this.parentElement;
             var initialsInput = initialsDropContainer.getElementsByTagName("input")[0];
@@ -373,11 +373,11 @@ window.onload = function() {
         // that are available for the current model and build the
         // associated drop down with these values
         var caller = ripe.loadedConfig
-            ? function(callback) {
+            ? function (callback) {
                   callback(ripe.loadedConfig);
               }
             : ripe.getConfig;
-        caller(function(result) {
+        caller(function (result) {
             var initials = result.initials || {};
             var profiles = initials.$profiles || {};
             var profilesKeys = Object.keys(profiles);
@@ -403,7 +403,7 @@ window.onload = function() {
     // it to the ready event (all internal structures loaded according
     // to values from the server side
     ripe.load();
-    ripe.bind("ready", function() {
+    ripe.bind("ready", function () {
         try {
             init(ripe);
         } catch (exception) {

--- a/src/python/ripe_demo/static/js/main.js
+++ b/src/python/ripe_demo/static/js/main.js
@@ -4,7 +4,7 @@
  */
 var FACES = ["side", "top", "front"];
 
-window.onload = function () {
+window.onload = function() {
     var element = document.getElementById("configurator");
     var _body = document.querySelector("body");
     var url = _body.dataset.url || "https://sandbox.platforme.com/api/";
@@ -35,7 +35,7 @@ window.onload = function () {
         guessUrl: guessUrl
     });
 
-    var randomize = async function () {
+    var randomize = async function() {
         var parts = [];
         for (var key in partsMap) {
             var triplets = partsMap[key];
@@ -46,7 +46,7 @@ window.onload = function () {
         await ripe.setParts(parts, true, { partEvents: false });
     };
 
-    var unique = function () {
+    var unique = function() {
         var count = 1;
         for (var key in partsMap) {
             var triplets = partsMap[key];
@@ -55,7 +55,7 @@ window.onload = function () {
         return count;
     };
 
-    var beautify = function (value) {
+    var beautify = function(value) {
         var buffer = [];
         var parts = value.split("_");
         for (var index = 0; index < parts.length; index++) {
@@ -65,7 +65,7 @@ window.onload = function () {
         return buffer.join(" ");
     };
 
-    var bestFace = function (config) {
+    var bestFace = function(config) {
         var faces = config.faces || [];
         var bestFace = null;
         for (var index = 0; index < FACES.length; index++) {
@@ -82,7 +82,7 @@ window.onload = function () {
         return faces.length > 0 ? faces[0] : null;
     };
 
-    var init = function (instance) {
+    var init = function(instance) {
         initBase(instance);
         initHeader(instance);
         initOAuth(instance);
@@ -90,10 +90,10 @@ window.onload = function () {
         initInitials(instance);
     };
 
-    var initBase = function () {
+    var initBase = function() {
         // registers for the key down event on the global document element
         // to listen to some of the key strokes (global operations)
-        document.addEventListener("keydown", async function (event) {
+        document.addEventListener("keydown", async function(event) {
             if (event.ctrlKey && event.keyCode === 90) {
                 await ripe.undo();
             }
@@ -104,25 +104,25 @@ window.onload = function () {
         });
     };
 
-    var initHeader = function () {
+    var initHeader = function() {
         var setPart = document.getElementById("set-part");
         var setMessage = document.getElementById("set-message");
         var getPrice = document.getElementById("get-price");
         var getCombinations = document.getElementById("get-combinations");
 
         setPart &&
-            setPart.addEventListener("click", function () {
+            setPart.addEventListener("click", function() {
                 randomize();
             });
 
         setMessage &&
-            setMessage.addEventListener("click", function () {
+            setMessage.addEventListener("click", function() {
                 alert("Not implemented");
             });
 
         getPrice &&
-            getPrice.addEventListener("click", function () {
-                ripe.getPrice(function (value) {
+            getPrice.addEventListener("click", function() {
+                ripe.getPrice(function(value) {
                     if (value) {
                         alert(String(value.total.price_final) + " " + value.total.currency);
                     } else {
@@ -132,8 +132,8 @@ window.onload = function () {
             });
 
         getCombinations &&
-            getCombinations.addEventListener("click", function () {
-                ripe.getCombinations(function (combinations) {
+            getCombinations.addEventListener("click", function() {
+                ripe.getCombinations(function(combinations) {
                     alert(
                         "There are <strong>" +
                             String(combinations.length.formatMoney(0)) +
@@ -144,15 +144,15 @@ window.onload = function () {
                 });
             });
 
-        ripe.bind("error", function (error, description) {
+        ripe.bind("error", function(error, description) {
             alert(error);
         });
 
-        ripe.bind("message", function (name, value) {
+        ripe.bind("message", function(name, value) {
             alert(name + " - " + value);
         });
 
-        ripe.bind("price", function (value) {
+        ripe.bind("price", function(value) {
             var price = document.getElementById("price");
             if (!value || !value.total) {
                 price.innerHTML = "N/A";
@@ -161,7 +161,7 @@ window.onload = function () {
             price.innerHTML = value.total.price_final + " " + value.total.currency;
         });
 
-        ripe.bind("combinations", function (value) {
+        ripe.bind("combinations", function(value) {
             for (var index = 0; index < value.length; index++) {
                 var triplet = value[index];
                 var part = triplet[0];
@@ -173,13 +173,13 @@ window.onload = function () {
         });
     };
 
-    var initOAuth = function () {
+    var initOAuth = function() {
         let oauthLogin = document.getElementById("oauth-login");
         let oauthLogout = document.getElementById("oauth-logout");
         let oauthOperation = document.getElementById("oauth-operation");
 
         oauthLogin &&
-            oauthLogin.addEventListener("click", function () {
+            oauthLogin.addEventListener("click", function() {
                 ripe.oauth({
                     clientId: clientId,
                     clientSecret: clientSecret,
@@ -189,13 +189,13 @@ window.onload = function () {
             });
 
         oauthLogout &&
-            oauthLogout.addEventListener("click", function () {
+            oauthLogout.addEventListener("click", function() {
                 ripe.unauth();
             });
 
         oauthOperation &&
-            oauthOperation.addEventListener("click", function () {
-                ripe.getOrders(function (result) {
+            oauthOperation.addEventListener("click", function() {
+                ripe.getOrders(function(result) {
                     alert("Retrieved " + String(result.length) + " orders");
                 });
             });
@@ -208,13 +208,13 @@ window.onload = function () {
         oauthLogout = oauthLogout || { style: {} };
         oauthOperation = oauthOperation || { style: {} };
 
-        ripe.bind("auth", function () {
+        ripe.bind("auth", function() {
             oauthLogin.style.display = "none";
             oauthLogout.style.display = "block";
             oauthOperation.style.display = "block";
         });
 
-        ripe.bind("unauth", function () {
+        ripe.bind("unauth", function() {
             oauthLogin.style.display = "block";
             oauthLogout.style.display = "none";
             oauthOperation.style.display = "none";
@@ -225,16 +225,16 @@ window.onload = function () {
         oauthOperation.style.display = "none";
     };
 
-    var initConfigurator = function () {
+    var initConfigurator = function() {
         // loads the config of the product to retrieve the
         // complete configuration of the product and be able
         // to define the visible frames and apply restrictions
         var caller = ripe.loadedConfig
-            ? function (callback) {
+            ? function(callback) {
                   callback(ripe.loadedConfig);
               }
             : ripe.getConfig;
-        caller(function (result) {
+        caller(function(result) {
             var frame0 = document.getElementById("frame-0");
             var frame6 = document.getElementById("frame-6");
             var frameTop = document.getElementById("frame-top");
@@ -275,7 +275,7 @@ window.onload = function () {
                 });
             }
 
-            frame0.addEventListener("click", function () {
+            frame0.addEventListener("click", function() {
                 if (result.frames > 9) {
                     configurator.changeFrame("side-9", {
                         revolutionDuration: 500
@@ -286,28 +286,28 @@ window.onload = function () {
                     });
                 }
             });
-            frame6.addEventListener("click", function () {
+            frame6.addEventListener("click", function() {
                 configurator.changeFrame("side-6", {
                     revolutionDuration: 500
                 });
             });
-            frameTop.addEventListener("click", function () {
+            frameTop.addEventListener("click", function() {
                 configurator.changeFrame("top-0", {
                     duration: 250
                 });
             });
-            frameFront.addEventListener("click", function () {
+            frameFront.addEventListener("click", function() {
                 configurator.changeFrame("front-0", {
                     duration: 250
                 });
             });
 
             image &&
-                image.bind("loaded", function () {
+                image.bind("loaded", function() {
                     console.log("frame-0 loaded");
                 });
 
-            setTimeout(function () {
+            setTimeout(function() {
                 if (result.frames > 9) {
                     image && image.setFrame("side-9");
                 }
@@ -320,7 +320,7 @@ window.onload = function () {
             });
             configurator.isFirst = true;
 
-            configurator.bind("loaded", function () {
+            configurator.bind("loaded", function() {
                 if (configurator.isFirst) configurator.isFirst = false;
                 else return;
                 if (result.faces.indexOf("side") !== -1) {
@@ -343,26 +343,26 @@ window.onload = function () {
         });
     };
 
-    var initInitials = function () {
+    var initInitials = function() {
         ripe.bindImage(document.getElementById("initials"), {
             showInitials: true
         });
 
-        ripe.bind("initials_extra", function (initialsExtra) {
+        ripe.bind("initials_extra", function(initialsExtra) {
             document.getElementById("initials-text").value =
                 initialsExtra.main && initialsExtra.main.initials
                     ? initialsExtra.main.initials
                     : "";
         });
 
-        document.getElementById("initials-text").addEventListener("keyup", function () {
+        document.getElementById("initials-text").addEventListener("keyup", function() {
             var initialsDrop = document.getElementById("initials-drop");
             var initialsDropContainer = initialsDrop.parentElement;
             var initialsInput = initialsDropContainer.getElementsByTagName("input")[0];
             ripe.setInitials(this.value, initialsInput.value);
         });
 
-        document.getElementById("initials-drop").onvalue_change = function () {
+        document.getElementById("initials-drop").onvalue_change = function() {
             var initialsText = document.getElementById("initials-text");
             var initialsDropContainer = this.parentElement;
             var initialsInput = initialsDropContainer.getElementsByTagName("input")[0];
@@ -373,11 +373,11 @@ window.onload = function () {
         // that are available for the current model and build the
         // associated drop down with these values
         var caller = ripe.loadedConfig
-            ? function (callback) {
+            ? function(callback) {
                   callback(ripe.loadedConfig);
               }
             : ripe.getConfig;
-        caller(function (result) {
+        caller(function(result) {
             var initials = result.initials || {};
             var profiles = initials.$profiles || {};
             var profilesKeys = Object.keys(profiles);
@@ -403,7 +403,7 @@ window.onload = function () {
     // it to the ready event (all internal structures loaded according
     // to values from the server side
     ripe.load();
-    ripe.bind("ready", function () {
+    ripe.bind("ready", function() {
         try {
             init(ripe);
         } catch (exception) {

--- a/test/js/visual.js
+++ b/test/js/visual.js
@@ -18,12 +18,12 @@ describe("Visual", function() {
             assert.strictEqual(instance.children[0], interactable);
         });
 
-        it("should deinit instance and unbind interactable", () => {
+        it("should deinit instance and unbind interactable", async () => {
             const instance = new base.ripe.Ripe("myswear", "vyner");
             const interactable = new base.ripe.Interactable(instance);
 
             instance.bindInteractable(interactable);
-            instance.deinit();
+            await instance.deinit();
 
             assert.strictEqual(interactable.owner, null);
             assert.strictEqual(instance.children.length, 0);
@@ -49,13 +49,13 @@ describe("Visual", function() {
             assert.strictEqual(imageElement.src.includes("frame=side-10"), true);
         });
 
-        it("should deinit image and stop updating", () => {
+        it("should deinit image and stop updating", async () => {
             const dom = new jsdom.JSDOM("<img id='image' />");
             const imageElement = dom.window.document.getElementById("image");
             const instance = new base.ripe.Ripe("myswear", "vyner");
             const image = instance.bindImage(imageElement);
 
-            instance.deinit();
+            await instance.deinit();
 
             assert.strictEqual(image.owner, null);
             assert.strictEqual(image.element, null);


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/341 |
| Dependencies | -- |
| Decisions | • **The symptoms of the problem:**<br>In the same build, when changing models with different number of thumbnails, in this case in brand "dummy", from the model "macho", "cube" or "bill", to the model "dummy", which will go from 3 thumbnails to 2 thumbails, the model can't be switched back. (See  [#341](https://github.com/ripe-tech/ripe-white/issues/341) for more details)<br>• **What the root cause issue was:**<br>`cancel` operation in two of the `Image`s would not be resolved so they would hang ripe-white. It would hang here:https://github.com/ripe-tech/ripe-sdk/blob/3450aa661f7fee03a9003c29ac89b64ffc18dc92/src/js/visual/image.js#L153 which would then hang here: https://github.com/ripe-tech/ripe-sdk/blob/3450aa661f7fee03a9003c29ac89b64ffc18dc92/src/js/base/ripe.js#L1130 and the flow would not go further from here: https://github.com/ripe-tech/ripe-sdk/blob/3450aa661f7fee03a9003c29ac89b64ffc18dc92/src/js/base/ripe.js#L1195 and here:https://github.com/ripe-tech/ripe-sdk/blob/3450aa661f7fee03a9003c29ac89b64ffc18dc92/src/js/base/ripe.js#L311<br>• Why this change fixes the root cause:<br>When destroying the thumbnails, `Image` `deinit` is called: https://github.com/ripe-tech/ripe-sdk/blob/3450aa661f7fee03a9003c29ac89b64ffc18dc92/src/js/visual/image.js#L198 As the callbacks are removed before being resolved, the promises would hang in limbo. Resolving these pending promises, fixes this bug. |
| Animated GIF | ![White-Dummy_dummy_fix](https://user-images.githubusercontent.com/22588915/80964030-0bf96e00-8e08-11ea-92ad-b2fefb3d03ce.gif) |
