### PR TITLE
Allow for an image without defined frame

### DIFF
--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -47,7 +47,7 @@ ripe.Image.prototype = ripe.build(ripe.Visual.prototype);
 ripe.Image.prototype.init = function() {
     ripe.Visual.prototype.init.call(this);
 
-    this.frame = this.options.frame || 0;
+    this.frame = this.options.frame || null;
     this.format = this.options.format || null;
     this.size = this.options.size || 1000;
     this.width = this.options.width || null;

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -49,10 +49,10 @@ ripe.Image.prototype.init = function() {
 
     this.frame = this.options.frame || null;
     this.format = this.options.format || null;
-    this.size = this.options.size || 1000;
+    this.size = this.options.size || null;
     this.width = this.options.width || null;
     this.height = this.options.height || null;
-    this.crop = this.options.crop || false;
+    this.crop = this.options.crop || null;
     this.mutations = this.options.mutations || false;
     this.showInitials = this.options.showInitials || false;
     this.initialsGroup = this.options.initialsGroup || null;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Fixes https://github.com/ripe-tech/ripe-retail-vendors/issues/42 |
| Decisions | When we had the [frame name hack](https://github.com/ripe-tech/ripe-sdk/commit/569d437409617bcf4e44f051d5690c34d9d044d2) in place, `Image`s with `frame = 0` (the default) would result in a request to RIPE Core without a defined frame. The removal of that hack in conjunction with the fallback in the constructor that I'm not removing made it impossible to request the binding of an `Image` without a pre-defined frame. Doing that is useful whenever we want to fallback to the build configuration to define the best frame to view a certain image configuration. An example is relying on `spec.json`'s `defaults`, which might define "the one that best displays" a part, which is what ripe-retail-vendors personalization plugins were relying on to get the correct frame. |
