### PR TITLE
Fixed "message" event

### DIFF
--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -1638,7 +1638,11 @@ ripe.Ripe.prototype._handleCtx = function(result) {
     if (result.choices && !ripe.equal(result.choices, this.choices)) {
         this.setChoices(result.choices);
     }
-    for (const [name, value] of result.messages) {
+
+    for (let i = 0; i < result.messages.length; i += 2) {
+        const name = result.messages[i];
+        const value = result.messages[i + 1];
+
         this.trigger("message", name, value);
     }
 };


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | `result.messages` method of getting the pair `name`, `value` was being treated similarly as it would an object with `object.entries()`, but it as it is an array it will give values that aren't what we want (see image below), so I fixed the for loop  |
| Image | <img width="748" alt="imagem" src="https://user-images.githubusercontent.com/22588915/83761931-dd70ec00-a66e-11ea-9eeb-373cdb197458.png"> |
