### PR TITLE
Fix authentication with key

### DIFF
--- a/src/js/base/api.js
+++ b/src/js/base/api.js
@@ -781,15 +781,14 @@ ripe.Ripe.prototype._getSwatchURL = function(options) {
 ripe.Ripe.prototype._build = function(options) {
     const url = options.url || "";
     const method = options.method || "GET";
+    const headers = options.headers || {};
     const params = options.params || {};
     const auth = options.auth || false;
     if (auth && this.sid !== undefined && this.sid !== null) {
         params.sid = this.sid;
     }
     if (auth && this.key !== undefined && this.key !== null) {
-        const headers = params.headers || {};
         headers["X-Secret-Key"] = this.key;
-        params.headers = headers;
     }
     if (
         auth &&
@@ -800,6 +799,7 @@ ripe.Ripe.prototype._build = function(options) {
     }
     options.url = url;
     options.method = method;
+    options.headers = headers;
     options.params = params;
     options.auth = auth;
     return options;

--- a/src/js/base/auth.js
+++ b/src/js/base/auth.js
@@ -208,15 +208,9 @@ ripe.Ripe.prototype.authKey = function(key, options, callback) {
     callback = typeof options === "function" ? options : callback;
     options = typeof options === "function" || options === undefined ? {} : options;
 
-    const headers = {
-        "X-Secret-Key": key
-    };
-    options.headers = headers;
+    this.key = key;
     this.accountMe(options, (result, isValid, request) => {
-        if (isValid) {
-            this.key = key;
-            this.trigger("auth");
-        }
+        if (isValid) this.trigger("auth");
         if (callback) callback(result, isValid, request);
     });
 };


### PR DESCRIPTION
```
  1) Auth
       #auth key
         should be able to authenticate with key:
     Error: Authorization requested but none is available
      at ripe.Ripe._build (src/js/base/api.js:799:15)
      at ripe.Ripe.accountMe (src/js/api/account.js:30:20)
      at ripe.Ripe.authKey (src/js/base/auth.js:215:10)
      at ./repos/ripe-sdk/src/js/base/auth.js:237:14
      at new Promise (<anonymous>)
      at ripe.Ripe.authKeyP (src/js/base/auth.js:236:12)
      at Context.<anonymous> (test/js/base/auth.js:39:35)
      at processImmediate (internal/timers.js:456:21)
```
