### PR TITLE
#426 Added messages event

### DIFF
--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -1638,6 +1638,7 @@ ripe.Ripe.prototype._handleCtx = function(result) {
     if (result.choices && !ripe.equal(result.choices, this.choices)) {
         this.setChoices(result.choices);
     }
+    this.trigger("messages", result.messages);
     for (const [name, value] of result.messages) {
         this.trigger("message", name, value);
     }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/426 |
| Dependencies | -- |
| Decisions | The need to create the event "messages" came the attemps on resolving https://github.com/ripe-tech/ripe-white/issues/426, which led to the devolpment of https://github.com/ripe-tech/ripe-commons-pluginus/pull/125  and https://github.com/ripe-tech/ripe-white/pull/477, but as it was incompatible with ripe-retail, (because of the events triggering order, the same reason that led to creation of the `messages-alert` component), it was decided to create this event "messages" which then is used in ripe-white: [ns/426-show_messages](https://github.com/ripe-tech/ripe-commons-pluginus/compare/master...ns/426-show_messages) |
| Animated GIF | -- |
