### PR TITLE
Fix method name of accountMe

### DIFF
--- a/src/js/api/account.js
+++ b/src/js/api/account.js
@@ -40,7 +40,7 @@ ripe.Ripe.prototype.accountMe = function(options, callback) {
  */
 ripe.Ripe.prototype.accountMeP = function(options) {
     return new Promise((resolve, reject) => {
-        this.me(options, (result, isValid, request) => {
+        this.accountMe(options, (result, isValid, request) => {
             isValid ? resolve(result) : reject(new ripe.RemoteError(request));
         });
     });


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Method `accountMeP` isn't working because `this.me` isn't defined. |
| Decisions | Fix method `accountMeP`with the right corresponding method. |