### PR TITLE
Support for invalid frame error handling

### DIFF
--- a/src/js/visual/configurator.js
+++ b/src/js/visual/configurator.js
@@ -542,13 +542,16 @@ ripe.Configurator.prototype.changeFrame = async function(frame, options = {}) {
     } catch (err) {
         // removes the locking classes as the current operation has been
         // finished, effectively re-allowing: dragging and animated operations
+        // and then re-throws the exception caused by update
         this.element.classList.remove("no-drag", "animating");
+        throw err;
     }
 
     // in case the change frame operation has been completed
     // target view and position has been reached, then it's
     // time collect the garbage and return control flow
     if (view === nextView && stepPosition === nextPosition) {
+        this.element.classList.remove("no-drag", "animating");
         return;
     }
 

--- a/src/js/visual/configurator.js
+++ b/src/js/visual/configurator.js
@@ -301,7 +301,7 @@ ripe.Configurator.prototype.deinit = async function() {
  * proper animation should be performed.
  *
  * This function is meant to be executed using a recursive approach
- * and ech run represents a "tick" of the operation.
+ * and ech run represents a "tick" of the animation operation.
  *
  * @param {Object} frame The new frame to display, can use both the minimal or the extended
  * format for the description of the frame.

--- a/src/js/visual/configurator.js
+++ b/src/js/visual/configurator.js
@@ -535,16 +535,14 @@ ripe.Configurator.prototype.changeFrame = async function(frame, options = {}) {
                 duration: animate ? duration : 0
             }
         );
-    } catch (error) {
+    } finally {
         this.element.classList.remove("no-drag", "animating");
-        throw error;
     }
 
     // in case the change frame operation has been completed
     // target view and position has been reached, then it's
     // time collect the garbage and return control flow
     if (view === nextView && stepPosition === nextPosition) {
-        this.element.classList.remove("no-drag", "animating");
         return;
     }
 

--- a/src/js/visual/configurator.js
+++ b/src/js/visual/configurator.js
@@ -527,13 +527,18 @@ ripe.Configurator.prototype.changeFrame = async function(frame, options = {}) {
     // configurator according to the current internal state (in data)
     // this operation waits for the proper drawing of the image (takes
     // some time and resources to be completed)
-    await this.update(
-        {},
-        {
-            animate: animate,
-            duration: animate ? duration : 0
-        }
-    );
+    try {
+        await this.update(
+            {},
+            {
+                animate: animate,
+                duration: animate ? duration : 0
+            }
+        );
+    } catch (error) {
+        this.element.classList.remove("no-drag", "animating");
+        throw error;
+    }
 
     // in case the change frame operation has been completed
     // target view and position has been reached, then it's

--- a/src/js/visual/configurator.js
+++ b/src/js/visual/configurator.js
@@ -369,6 +369,7 @@ ripe.Configurator.prototype.changeFrame = async function(frame, options = {}) {
     // in case the current view and position are already set then returns
     // the control flow immediately (animation safeguard)
     if (safe && this.element.dataset.view === nextView && position === nextPosition) {
+        this.element.classList.remove("no-drag", "animating");
         return;
     }
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Related to https://github.com/ripe-tech/ripe-sdk-components-vue/issues/1. It is necessary to make the `configurator` solution more resilient to wrong input. |
| Dependencies | -- |
| Decisions | When an invalid frame is given, and exception is transported to the higher level. However, if a valid frame is later given, it will be ignored since the class `animating` is still applied to the `configurator`. It is necessary to catch the exception thrown by `update` when an invalid frame is given and remove that class, not allowing the recursive action to continue and making it possible to later give a valid frame. |
| Animated GIF | **Before:** <br> ![Jul-23-2020 11-23-17](https://user-images.githubusercontent.com/25725586/88276529-1b85a600-ccd7-11ea-8545-ce0de0755fef.gif)<br> **After:** <br>![solution](https://user-images.githubusercontent.com/25725586/88276565-2b9d8580-ccd7-11ea-8118-e8bbb540d088.gif)|
