### PR TITLE
Resize method for Image

### DIFF
--- a/src/js/visual/configurator.js
+++ b/src/js/visual/configurator.js
@@ -107,51 +107,29 @@ ripe.Configurator.prototype.init = function() {
 };
 
 /**
- * Resizes the configurator's DOM element to 'size' pixels.
- * This action is performed by setting both the attributes from
- * the HTML elements and the style.
- *
- * @param {Number} size The number of pixels to resize to.
+ * The Configurator deinitializer, to be called (by the owner) when
+ * it should stop responding to updates so that any necessary
+ * cleanup operations can be executed.
  */
-ripe.Configurator.prototype.resize = async function(size) {
-    if (this.element === undefined) {
-        return;
+ripe.Configurator.prototype.deinit = async function() {
+    await this.cancel();
+
+    while (this.element.firstChild) {
+        this.element.removeChild(this.element.firstChild);
     }
 
-    size = size || this.element.clientWidth;
-    if (this.currentSize === size) {
-        return;
+    for (const bind in this._ownerBinds) {
+        this.owner.unbind(bind, this._ownerBinds[bind]);
     }
 
-    const area = this.element.querySelector(".area");
-    const frontMask = this.element.querySelector(".front-mask");
-    const back = this.element.querySelector(".back");
-    const mask = this.element.querySelector(".mask");
-    area.width = size * this.pixelRatio;
-    area.height = size * this.pixelRatio;
-    area.style.width = size + "px";
-    area.style.height = size + "px";
-    frontMask.width = size;
-    frontMask.height = size;
-    frontMask.style.width = size + "px";
-    frontMask.style.height = size + "px";
-    frontMask.style.marginLeft = `-${String(size)}px`;
-    back.width = size * this.pixelRatio;
-    back.height = size * this.pixelRatio;
-    back.style.width = size + "px";
-    back.style.height = size + "px";
-    back.style.marginLeft = `-${String(size)}px`;
-    mask.width = size;
-    mask.height = size;
-    mask.style.width = size + "px";
-    mask.style.height = size + "px";
-    this.currentSize = size;
-    await this.update(
-        {},
-        {
-            force: true
-        }
-    );
+    this._removeElementHandlers();
+
+    if (this._observer) this._observer.disconnect();
+
+    this._finalize = null;
+    this._observer = null;
+
+    ripe.Visual.prototype.deinit.call(this);
 };
 
 /**
@@ -271,29 +249,51 @@ ripe.Configurator.prototype.cancel = async function(options = {}) {
 };
 
 /**
- * The Configurator deinitializer, to be called (by the owner) when
- * it should stop responding to updates so that any necessary
- * cleanup operations can be executed.
+ * Resizes the configurator's DOM element to 'size' pixels.
+ * This action is performed by setting both the attributes from
+ * the HTML elements and the style.
+ *
+ * @param {Number} size The number of pixels to resize to.
  */
-ripe.Configurator.prototype.deinit = async function() {
-    await this.cancel();
-
-    while (this.element.firstChild) {
-        this.element.removeChild(this.element.firstChild);
+ripe.Configurator.prototype.resize = async function(size) {
+    if (this.element === undefined) {
+        return;
     }
 
-    for (const bind in this._ownerBinds) {
-        this.owner.unbind(bind, this._ownerBinds[bind]);
+    size = size || this.element.clientWidth;
+    if (this.currentSize === size) {
+        return;
     }
 
-    this._removeElementHandlers();
-
-    if (this._observer) this._observer.disconnect();
-
-    this._finalize = null;
-    this._observer = null;
-
-    ripe.Visual.prototype.deinit.call(this);
+    const area = this.element.querySelector(".area");
+    const frontMask = this.element.querySelector(".front-mask");
+    const back = this.element.querySelector(".back");
+    const mask = this.element.querySelector(".mask");
+    area.width = size * this.pixelRatio;
+    area.height = size * this.pixelRatio;
+    area.style.width = size + "px";
+    area.style.height = size + "px";
+    frontMask.width = size;
+    frontMask.height = size;
+    frontMask.style.width = size + "px";
+    frontMask.style.height = size + "px";
+    frontMask.style.marginLeft = `-${String(size)}px`;
+    back.width = size * this.pixelRatio;
+    back.height = size * this.pixelRatio;
+    back.style.width = size + "px";
+    back.style.height = size + "px";
+    back.style.marginLeft = `-${String(size)}px`;
+    mask.width = size;
+    mask.height = size;
+    mask.style.width = size + "px";
+    mask.style.height = size + "px";
+    this.currentSize = size;
+    await this.update(
+        {},
+        {
+            force: true
+        }
+    );
 };
 
 /**

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -219,11 +219,9 @@ ripe.Image.prototype.setFrame = function(frame, options) {
 };
 
 /**
- * Updates the size of the Image.
+ * Resizes the Image's DOM element to 'size' pixels.
  *
- * @param {String} frame The Ripe instance frame to display.
- * @param {Object} options An object with options to configure
- * the setting of the frame.
+ * @param {String} size The number of pixels to resize to.
  */
 ripe.Image.prototype.resize = function(size) {
     this.size = size;

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -72,6 +72,22 @@ ripe.Image.prototype.init = function() {
 };
 
 /**
+ * The Image deinitializer, to be called (by the owner) when
+ * it should stop responding to updates so that any necessary
+ * cleanup operations can be executed.
+ */
+ripe.Image.prototype.deinit = async function() {
+    await this.cancel();
+
+    this._unregisterHandlers();
+
+    this._observer = null;
+    this.initialsBuilder = null;
+
+    ripe.Visual.prototype.deinit.call(this);
+};
+
+/**
  * This function is called (by the owner) whenever its state changes
  * so that the Image can update itself for the new state.
  *
@@ -191,19 +207,14 @@ ripe.Image.prototype.cancel = async function(options = {}) {
 };
 
 /**
- * The Image deinitializer, to be called (by the owner) when
- * it should stop responding to updates so that any necessary
- * cleanup operations can be executed.
+ * Resizes the Image's DOM element to 'size' pixels, both the
+ * width and the height of the image will reflect this value.
+ *
+ * @param {String} size The number of pixels to resize to.
  */
-ripe.Image.prototype.deinit = async function() {
-    await this.cancel();
-
-    this._unregisterHandlers();
-
-    this._observer = null;
-    this.initialsBuilder = null;
-
-    ripe.Visual.prototype.deinit.call(this);
+ripe.Image.prototype.resize = function(size) {
+    this.size = size;
+    this.update();
 };
 
 /**
@@ -215,16 +226,6 @@ ripe.Image.prototype.deinit = async function() {
  */
 ripe.Image.prototype.setFrame = function(frame, options) {
     this.frame = frame;
-    this.update();
-};
-
-/**
- * Resizes the Image's DOM element to 'size' pixels.
- *
- * @param {String} size The number of pixels to resize to.
- */
-ripe.Image.prototype.resize = function(size) {
-    this.size = size;
     this.update();
 };
 

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -219,6 +219,19 @@ ripe.Image.prototype.setFrame = function(frame, options) {
 };
 
 /**
+ * Updates the size of the Image.
+ *
+ * @param {String} frame The Ripe instance frame to display.
+ * @param {Object} options An object with options to configure
+ * the setting of the frame.
+ */
+ripe.Image.prototype.resize = function(size) {
+    this.size = size;
+    this.update();
+};
+
+
+/**
  * Updates the Image's 'initialsBuilder' function.
  *
  * @param {Function} builder The new 'initialsBuilder' function

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -230,7 +230,6 @@ ripe.Image.prototype.resize = function(size) {
     this.update();
 };
 
-
 /**
  * Updates the Image's 'initialsBuilder' function.
  *


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Related to https://github.com/ripe-tech/ripe-sdk-components-vue/issues/6 |
| Dependencies | -- |
| Decisions | There was no way of resizing an image after its initiation. The `resize` method updates the `size` parameter and calls the `update` method of `Image`, which updates it to a new state. |
| Animated GIF | Example: <br> ![Jul-23-2020 11-40-24](https://user-images.githubusercontent.com/25725586/88277908-686a7c00-ccd9-11ea-8a82-7a7eb041ffe6.gif)|
