### PR TITLE
Image update options

### DIFF
--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -97,14 +97,13 @@ ripe.Image.prototype.deinit = async function() {
 ripe.Image.prototype.update = async function(state, options = {}) {
     // gathers the complete set of data values from the element if existent
     // defaulting to the instance one in case their are not defined
-    const frame = this.element.dataset.frame || this.frame;
-    const format = this.element.dataset.format || this.format;
-    const size = this.element.dataset.size || this.size;
-    const width = this.element.dataset.width || this.width;
-    const height = this.element.dataset.height || this.height;
-    const crop = this.element.dataset.crop || this.crop;
-    const showInitials = options.showInitials || this.showInitials;
-    const initialsGroup = this.element.dataset.initialsGroup || this.initialsGroup;
+    const frame = options.frame || this.element.dataset.frame || this.frame;
+    const format = options.format || this.element.dataset.format || this.format;
+    const size = options.size || this.element.dataset.size || this.size;
+    const width = options.width || this.element.dataset.width || this.width;
+    const height = options.height || this.element.dataset.height || this.height;
+    const crop = options.crop || this.element.dataset.crop || this.crop;
+    const initialsGroup = options.initialsGroup || this.element.dataset.initialsGroup || this.initialsGroup;
 
     // in case the state is defined tries to gather the appropriate
     // sate options for both initials and engraving taking into
@@ -115,7 +114,7 @@ ripe.Image.prototype.update = async function(state, options = {}) {
         this.engraving = base.engraving || null;
     }
 
-    const initialsSpec = showInitials
+    const initialsSpec = this.showInitials
         ? this.initialsBuilder(this.initials, this.engraving, this.element)
         : {};
 
@@ -227,6 +226,16 @@ ripe.Image.prototype.resize = function(size) {
  */
 ripe.Image.prototype.setFrame = function(frame, options) {
     this.frame = frame;
+    this.update();
+};
+
+/**
+ * Updates the Image's 'showInitials' flag.
+ *
+ * @param {String} value The new 'showInitials' value to be used.
+ */
+ripe.Image.prototype.setShowInitials = function(value) {
+    this.showInitials = value;
     this.update();
 };
 

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -103,7 +103,8 @@ ripe.Image.prototype.update = async function(state, options = {}) {
     const width = options.width || this.element.dataset.width || this.width;
     const height = options.height || this.element.dataset.height || this.height;
     const crop = options.crop || this.element.dataset.crop || this.crop;
-    const initialsGroup = options.initialsGroup || this.element.dataset.initialsGroup || this.initialsGroup;
+    const initialsGroup =
+        options.initialsGroup || this.element.dataset.initialsGroup || this.initialsGroup;
 
     // in case the state is defined tries to gather the appropriate
     // sate options for both initials and engraving taking into

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -97,14 +97,13 @@ ripe.Image.prototype.deinit = async function() {
 ripe.Image.prototype.update = async function(state, options = {}) {
     // gathers the complete set of data values from the element if existent
     // defaulting to the instance one in case their are not defined
-    const frame = options.frame || this.element.dataset.frame || this.frame;
-    const format = options.format || this.element.dataset.format || this.format;
-    const size = options.size || this.element.dataset.size || this.size;
-    const width = options.width || this.element.dataset.width || this.width;
-    const height = options.height || this.element.dataset.height || this.height;
-    const crop = options.crop || this.element.dataset.crop || this.crop;
-    const initialsGroup =
-        options.initialsGroup || this.element.dataset.initialsGroup || this.initialsGroup;
+    const frame = this.element.dataset.frame || this.frame;
+    const format = this.element.dataset.format || this.format;
+    const size = this.element.dataset.size || this.size;
+    const width = this.element.dataset.width || this.width;
+    const height = this.element.dataset.height || this.height;
+    const crop = this.element.dataset.crop || this.crop;
+    const initialsGroup = this.element.dataset.initialsGroup || this.initialsGroup;
 
     // in case the state is defined tries to gather the appropriate
     // sate options for both initials and engraving taking into
@@ -231,12 +230,13 @@ ripe.Image.prototype.setFrame = function(frame, options) {
 };
 
 /**
- * Updates the Image's 'showInitials' flag.
+ * Updates the Image's 'showInitials' flag that indicates
+ * if the initials should be display in the image.
  *
- * @param {String} value The new 'showInitials' value to be used.
+ * @param {String} showInitials If the image should display initials.
  */
-ripe.Image.prototype.setShowInitials = function(value) {
-    this.showInitials = value;
+ripe.Image.prototype.setShowInitials = function(showInitials) {
+    this.showInitials = showInitials;
     this.update();
 };
 

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -103,6 +103,7 @@ ripe.Image.prototype.update = async function(state, options = {}) {
     const width = this.element.dataset.width || this.width;
     const height = this.element.dataset.height || this.height;
     const crop = this.element.dataset.crop || this.crop;
+    const showInitials = options.showInitials || this.showInitials;
     const initialsGroup = this.element.dataset.initialsGroup || this.initialsGroup;
 
     // in case the state is defined tries to gather the appropriate
@@ -114,7 +115,7 @@ ripe.Image.prototype.update = async function(state, options = {}) {
         this.engraving = base.engraving || null;
     }
 
-    const initialsSpec = this.showInitials
+    const initialsSpec = showInitials
         ? this.initialsBuilder(this.initials, this.engraving, this.element)
         : {};
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Related to https://github.com/ripe-tech/ripe-sdk-components-vue/issues/3 |
| Dependencies | -- |
| Decisions | When an image is created, there is no way of changing the options (eg. crop, format, initialsGroup, etc.) after its initialization. Since the method `update` already received options but was not using it, changes were made to allow overriding the already defined options with the ones provided. <br><br> A method for changing the `showInitials` flag was also added, allowing for the disabling of the personalization visualization.  <br><br>**Reasoning**: These two changes are necessary to implement prop reactivity, meaning that after the image component is initialized, already defined options might need changing. Since all changes are connected to the method `update`, they were implemented there. |
| Animated GIF | -- |
