### PR TITLE
Update options in configurator after initialization

### DIFF
--- a/src/js/base/interactable.js
+++ b/src/js/base/interactable.js
@@ -43,16 +43,6 @@ ripe.Interactable.prototype.init = function() {
 };
 
 /**
- * Callback function to be called when the owner configurator has
- * been changed and some kind of visual update should take place.
- *
- * @param {Object} state The new configuration state.
- * @param {Object} options Set of update options that change the way
- * the update operation is going to be performed.
- */
-ripe.Interactable.prototype.update = async function(state, options = {}) {};
-
-/**
  * The deinitializer to be called (by the owner) when
  * it should stop responding to updates so that any necessary
  * cleanup operations can be executed.
@@ -62,3 +52,27 @@ ripe.Interactable.prototype.deinit = async function() {
 
     ripe.Observable.prototype.deinit.call(this);
 };
+
+/**
+ * Updates the current set of options (object) with the partial
+ * options object provided as argument.
+ *
+ * The merge operation between both objects may override the current
+ * set of configurations.
+ *
+ * @param {Object} options Map with the partial set of values to update
+ * the currently set options
+ */
+ripe.Interactable.prototype.updateOptions = async function(options) {
+    this.options = Object.assign(this.options, options);
+};
+
+/**
+ * Callback function to be called when the owner configurator has
+ * been changed and some kind of visual update should take place.
+ *
+ * @param {Object} state The new configuration state.
+ * @param {Object} options Set of update options that change the way
+ * the update operation is going to be performed.
+ */
+ripe.Interactable.prototype.update = async function(state, options = {}) {};

--- a/src/js/base/observable.js
+++ b/src/js/base/observable.js
@@ -21,9 +21,18 @@ ripe.Observable = function() {
 };
 
 /**
- * @ignore
+ * The initializer of the class, called whenever this
+ * observable starts its activity.
  */
 ripe.Observable.prototype.init = function() {};
+
+/**
+ * The deinitializer of the class, called whenever this
+ * observable ceases its activity.
+ */
+ripe.Observable.prototype.deinit = async function() {
+    this.callbacks = null;
+};
 
 /**
  * Binds to an event by providing a block that will receive the event payload as a
@@ -96,14 +105,6 @@ ripe.Observable.prototype.runCallbacksWait = async function(event, ...args) {
 ripe.Observable.prototype.runCallbackNoWait = async function(event, ...args) {
     const result = await this.runCallbacks(event, false, ...args);
     return result;
-};
-
-/**
- * The deinitializer of the class, called whenever this
- * observable ceases its activity.
- */
-ripe.Observable.prototype.deinit = async function() {
-    this.callbacks = null;
 };
 
 /**

--- a/src/js/visual/configurator.js
+++ b/src/js/visual/configurator.js
@@ -133,6 +133,39 @@ ripe.Configurator.prototype.deinit = async function() {
 };
 
 /**
+ * Updates configurator current options with the ones provided.
+ *
+ * @param {*} options Set of optional parameters to adjust the Configurator, such as:
+ * - 'sensitivity' - Rotation sensitivity to the user mouse drag action.
+ * - 'duration' - The duration in milliseconds that the transition should take.
+ * - 'useMasks' - Usage of masks in the current model, necessary for the part highlighting action.
+ * - 'configAnimate' - The configurator animation style: 'simple' (fade in), 'cross' (crossfade) or 'null'.
+ */
+ripe.Configurator.prototype.updateOptions = async function(options) {
+    this.width = options.width || this.width;
+    this.height = options.height || this.height;
+    this.format = options.format || this.format;
+    this.size = options.size || this.size;
+    this.mutations = options.mutations || this.mutations;
+    this.maxSize = options.maxSize || this.maxSize;
+    this.pixelRatio = options.pixelRation || this.pixelRatio;
+    this.sensitivity = options.sensitivity || this.sensitivity;
+    this.verticalThreshold = options.verticalThreshold || this.verticalThreshold;
+    this.clickThreshold = options.clickThreshold || this.clickThreshold;
+    this.interval = options.interval || this.interval;
+    this.duration = options.duration || this.duration;
+    this.preloadDelay = options.preloadDelay || this.preloadDelay;
+    this.maskOpacity = options.maskOpacity || this.maskOpacity;
+    this.maskDuration = options.maskDuration || this.maskDuration;
+    this.noMasks = options.noMasks || this.noMasks;
+    this.useMasks = options.useMasks || this.useMasks;
+    this.configAnimate = options.configAnimate || this.configAnimate;
+    this.viewAnimate = options.viewAnimate || this.viewAnimate;
+
+    await this.update();
+};
+
+/**
  * This function is called (by the owner) whenever its state changes
  * so that the Configurator can update itself for the new state.
  *

--- a/src/js/visual/configurator.js
+++ b/src/js/visual/configurator.js
@@ -135,13 +135,17 @@ ripe.Configurator.prototype.deinit = async function() {
 /**
  * Updates configurator current options with the ones provided.
  *
- * @param {*} options Set of optional parameters to adjust the Configurator, such as:
+ * @param {Object} options Set of optional parameters to adjust the Configurator, such as:
  * - 'sensitivity' - Rotation sensitivity to the user mouse drag action.
  * - 'duration' - The duration in milliseconds that the transition should take.
  * - 'useMasks' - Usage of masks in the current model, necessary for the part highlighting action.
  * - 'configAnimate' - The configurator animation style: 'simple' (fade in), 'cross' (crossfade) or 'null'.
+ * @param {Boolean} update If an update operation should be executed after
+ * the options updated operation has been performed.
  */
-ripe.Configurator.prototype.updateOptions = async function(options) {
+ripe.Configurator.prototype.updateOptions = async function(options, update = true) {
+    ripe.Visual.prototype.updateOptions.call(this, options);
+
     this.width = options.width || this.width;
     this.height = options.height || this.height;
     this.format = options.format || this.format;
@@ -162,7 +166,7 @@ ripe.Configurator.prototype.updateOptions = async function(options) {
     this.configAnimate = options.configAnimate || this.configAnimate;
     this.viewAnimate = options.viewAnimate || this.viewAnimate;
 
-    await this.update();
+    if (update) await this.update();
 };
 
 /**


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Related to https://github.com/ripe-tech/ripe-sdk-components-vue/issues/2 |
| Dependencies | -- |
| Decisions | Method to update configurator options (format, sensitivity, configAnimate, duration, etc) after its initialization. <br><br> **Reasoning**: The configurator components needs a way of updating the configurator options, which was impossible after its initialization. |
| Animated GIF | -- |
