### PR TITLE
Fix non-JSON request parsing

### DIFF
--- a/src/js/base/api.js
+++ b/src/js/base/api.js
@@ -332,7 +332,11 @@ ripe.Ripe.prototype._requestURLFetch = function(url, options, callback) {
             let result = null;
             const isValid = validCodes.includes(response.status);
             try {
-                result = await response.json();
+                if (response.headers.get("content-type").toLowerCase().startsWith("application/json")) {
+                    result = await response.json();
+                } else {
+                    result = await response.blob();
+                }
             } catch (error) {
                 response.error = response.error || error;
                 callback.call(context, result, isValid, response);

--- a/src/js/base/api.js
+++ b/src/js/base/api.js
@@ -331,8 +331,9 @@ ripe.Ripe.prototype._requestURLFetch = function(url, options, callback) {
         .then(async response => {
             let result = null;
             const isValid = validCodes.includes(response.status);
+            const contentType = response.headers.get("content-type").toLowerCase();
             try {
-                if (response.headers.get("content-type").toLowerCase().startsWith("application/json")) {
+                if (contentType.startsWith("application/json")) {
                     result = await response.json();
                 } else {
                     result = await response.blob();

--- a/test/js/api/brand.js
+++ b/test/js/api/brand.js
@@ -17,7 +17,7 @@ describe("BrandAPI", function() {
                 method: "minimum_initials"
             });
 
-            assert.strictEqual(result, 1);
+            assert.strictEqual(result, "1");
 
             result = await remote.runLogicP({
                 brand: "dummy",
@@ -25,7 +25,7 @@ describe("BrandAPI", function() {
                 method: "maximum_initials"
             });
 
-            assert.strictEqual(result, 4);
+            assert.strictEqual(result, "4");
         });
     });
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | Only parse JSON when the content-type matches, otherwise return the raw response. The adapter that uses `XMLHttpRequest` was already dealing with this so it didn't need adapting. Motivated by the need to call the logic methods from builds that don't translate to JSON, such as `supported_characters`, which return strings or numbers. <br/> This change changed the expectations of calling `minimum_initials` and `maximum_initials` through `runLogicP`, since it now returns a String rather than a Number because the `runLogic` response is not JSON and therefore should not be converted (so we lose the `JSON.parse("1")` that was converting the response to `Number`). Maybe there could be a specific RIPE SDK method to get the minimum and maximum initials as numbers, but right now it's just following [common](https://github.com/hivesolutions/yonius/blob/master/js/api/api.js#L144) API client semantics. |
