### PR TITLE
#195: RIPE SDK compatibility with Nuxt.js under Vercel

### DIFF
--- a/src/js/base/compat.js
+++ b/src/js/base/compat.js
@@ -71,7 +71,10 @@ if (
         const mixedModuleName = "Xmlhttprequest";
         const correctModuleName = mixedModuleName.toLowerCase();
         XMLHttpRequest = require(correctModuleName).XMLHttpRequest;
-    } else {
+        // eslint-disable-next-line camelcase
+    } else if (typeof __webpack_require__ !== "undefined" && typeof window !== "undefined") {
+        XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
+    } else if (typeof window !== "undefined") {
         XMLHttpRequest = window.XMLHttpRequest;
     }
 }
@@ -86,12 +89,14 @@ if (
 ) {
     var fetch = null;
     if (
+         // eslint-disable-next-line camelcase
+        typeof __webpack_require__ !== "undefined" ||
         // eslint-disable-next-line camelcase
-        typeof __webpack_require__ === "undefined" &&
-        (typeof navigator === "undefined" || navigator.product !== "ReactNative")
+        (typeof __webpack_require__ === "undefined" &&
+        (typeof navigator === "undefined" || navigator.product !== "ReactNative"))
     ) {
-        fetch = require("node-fetch");
-    } else {
+        fetch = require("node-fetch").default;
+    } else if (typeof window !== "undefined") {
         fetch = window.fetch;
     }
 }

--- a/src/js/base/compat.js
+++ b/src/js/base/compat.js
@@ -70,20 +70,18 @@ if (
         // (https://github.com/react-native-community/discussions-and-proposals/issues/120)
         const mixedModuleName = "Xmlhttprequest";
         const correctModuleName = mixedModuleName.toLowerCase();
-        try {
-            XMLHttpRequest = require(correctModuleName).XMLHttpRequest;
-        } catch (err) {}
+        XMLHttpRequest = require(correctModuleName).XMLHttpRequest;
     } else if (typeof window !== "undefined") {
         XMLHttpRequest = window.XMLHttpRequest;
-    } else if (typeof require !== "undefined") {
+        // eslint-disable-next-line camelcase
+    } else if (typeof require !== "undefined" && typeof __webpack_require__ !== "undefined") {
         const mixedModuleName = "Xmlhttprequest";
         const correctModuleName = mixedModuleName.toLowerCase();
-        try {
-            // catch exception if module not found, which happens when
-            // the sdk is used by server-side nuxt.js applications. It
-            // will default to the usage of fetch.
-            XMLHttpRequest = require(correctModuleName).XMLHttpRequest;
-        } catch (err) {}
+        // using a plain require call to load the module, since using
+        // the webpack call will result in module not found by nuxt.js
+        // applications
+        // eslint-disable-next-line camelcase
+        XMLHttpRequest = __non_webpack_require__(correctModuleName).XMLHttpRequest;
     }
 }
 

--- a/src/js/base/compat.js
+++ b/src/js/base/compat.js
@@ -20,7 +20,7 @@ if (
  *
  * @ignore
  */
-ripe.assign = function(target) {
+ripe.assign = function (target) {
     if (typeof Object.assign === "function") {
         return Object.assign.apply(this, arguments);
     }
@@ -48,7 +48,7 @@ ripe.assign = function(target) {
 /**
  * @ignore
  */
-ripe.build = function() {
+ripe.build = function () {
     const _arguments = Array.prototype.slice.call(arguments);
     _arguments.unshift({});
     return ripe.assign.apply(this, _arguments);
@@ -70,12 +70,20 @@ if (
         // (https://github.com/react-native-community/discussions-and-proposals/issues/120)
         const mixedModuleName = "Xmlhttprequest";
         const correctModuleName = mixedModuleName.toLowerCase();
-        XMLHttpRequest = require(correctModuleName).XMLHttpRequest;
-        // eslint-disable-next-line camelcase
-    } else if (typeof __webpack_require__ !== "undefined" && typeof window !== "undefined") {
-        XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
+        try {
+            XMLHttpRequest = require(correctModuleName).XMLHttpRequest;
+        } catch (err) {}
     } else if (typeof window !== "undefined") {
         XMLHttpRequest = window.XMLHttpRequest;
+    } else if (typeof require !== "undefined") {
+        const mixedModuleName = "Xmlhttprequest";
+        const correctModuleName = mixedModuleName.toLowerCase();
+        try {
+            // catch exception if module not found, which happens when
+            // the sdk is used by server-side nuxt.js applications. It
+            // will default to the usage of fetch.
+            XMLHttpRequest = require(correctModuleName).XMLHttpRequest;
+        } catch (err) {}
     }
 }
 
@@ -89,15 +97,15 @@ if (
 ) {
     var fetch = null;
     if (
-         // eslint-disable-next-line camelcase
-        typeof __webpack_require__ !== "undefined" ||
         // eslint-disable-next-line camelcase
-        (typeof __webpack_require__ === "undefined" &&
-        (typeof navigator === "undefined" || navigator.product !== "ReactNative"))
+        typeof __webpack_require__ === "undefined" &&
+        (typeof navigator === "undefined" || navigator.product !== "ReactNative")
     ) {
         fetch = require("node-fetch").default;
     } else if (typeof window !== "undefined") {
         fetch = window.fetch;
+    } else if (typeof require !== "undefined") {
+        fetch = require("node-fetch").default;
     }
 }
 

--- a/src/js/base/compat.js
+++ b/src/js/base/compat.js
@@ -75,9 +75,8 @@ if (
         XMLHttpRequest = window.XMLHttpRequest;
         // eslint-disable-next-line camelcase
     } else if (typeof __webpack_require__ !== "undefined") {
-        // using a plain require call to load the module, since using
-        // the webpack call will result in module not found by nuxt.js
-        // applications
+        // use a runtime 'require' call that is
+        // not parsed by webpack
         // eslint-disable-next-line no-undef
         XMLHttpRequest = __non_webpack_require__("xmlhttprequest").XMLHttpRequest;
     }

--- a/src/js/base/compat.js
+++ b/src/js/base/compat.js
@@ -20,7 +20,7 @@ if (
  *
  * @ignore
  */
-ripe.assign = function (target) {
+ripe.assign = function(target) {
     if (typeof Object.assign === "function") {
         return Object.assign.apply(this, arguments);
     }
@@ -48,7 +48,7 @@ ripe.assign = function (target) {
 /**
  * @ignore
  */
-ripe.build = function () {
+ripe.build = function() {
     const _arguments = Array.prototype.slice.call(arguments);
     _arguments.unshift({});
     return ripe.assign.apply(this, _arguments);

--- a/src/js/base/compat.js
+++ b/src/js/base/compat.js
@@ -60,7 +60,9 @@ if (
     typeof XMLHttpRequest === "undefined" // eslint-disable-line no-use-before-define
 ) {
     var XMLHttpRequest = null;
-    if (
+    if (typeof window !== "undefined" && typeof window.XMLHttpRequest !== "undefined") {
+        XMLHttpRequest = window.XMLHttpRequest;
+    } else if (
         // eslint-disable-next-line camelcase
         typeof __webpack_require__ === "undefined" &&
         (typeof navigator === "undefined" || navigator.product !== "ReactNative")
@@ -71,12 +73,7 @@ if (
         const mixedModuleName = "Xmlhttprequest";
         const correctModuleName = mixedModuleName.toLowerCase();
         XMLHttpRequest = require(correctModuleName).XMLHttpRequest;
-    } else if (typeof window !== "undefined") {
-        XMLHttpRequest = window.XMLHttpRequest;
-        // eslint-disable-next-line camelcase
-    } else if (typeof __non_webpack_require__ !== "undefined") {
-        // use a runtime 'require' call that is
-        // not parsed by webpack
+    } else if (typeof __non_webpack_require__ !== "undefined") { // eslint-disable-line camelcase
         // eslint-disable-next-line no-undef
         XMLHttpRequest = __non_webpack_require__("xmlhttprequest").XMLHttpRequest;
     }
@@ -91,18 +88,15 @@ if (
     typeof fetch === "undefined" // eslint-disable-line no-use-before-define
 ) {
     var fetch = null;
-    if (
+    if (typeof window !== "undefined" && typeof window.fetch !== "undefined") {
+        fetch = window.fetch;
+    } else if (
         // eslint-disable-next-line camelcase
         typeof __webpack_require__ === "undefined" &&
         (typeof navigator === "undefined" || navigator.product !== "ReactNative")
     ) {
         fetch = require("node-fetch").default;
-    } else if (typeof window !== "undefined") {
-        fetch = window.fetch;
-        // eslint-disable-next-line camelcase
-    } else if (typeof __non_webpack_require__ !== "undefined") {
-        // use a runtime 'require' call that is
-        // not parsed by webpack
+    } else if (typeof __non_webpack_require__ !== "undefined") { // eslint-disable-line camelcase
         // eslint-disable-next-line no-undef
         fetch = __non_webpack_require__("node-fetch").default;
     }

--- a/src/js/base/compat.js
+++ b/src/js/base/compat.js
@@ -20,7 +20,7 @@ if (
  *
  * @ignore
  */
-ripe.assign = function(target) {
+ripe.assign = function (target) {
     if (typeof Object.assign === "function") {
         return Object.assign.apply(this, arguments);
     }
@@ -48,7 +48,7 @@ ripe.assign = function(target) {
 /**
  * @ignore
  */
-ripe.build = function() {
+ripe.build = function () {
     const _arguments = Array.prototype.slice.call(arguments);
     _arguments.unshift({});
     return ripe.assign.apply(this, _arguments);
@@ -74,7 +74,7 @@ if (
     } else if (typeof window !== "undefined") {
         XMLHttpRequest = window.XMLHttpRequest;
         // eslint-disable-next-line camelcase
-    } else if (typeof __webpack_require__ !== "undefined") {
+    } else if (typeof __non_webpack_require__ !== "undefined") {
         // use a runtime 'require' call that is
         // not parsed by webpack
         // eslint-disable-next-line no-undef
@@ -100,8 +100,11 @@ if (
     } else if (typeof window !== "undefined") {
         fetch = window.fetch;
         // eslint-disable-next-line camelcase
-    } else if (typeof __webpack_require__ !== "undefined") {
-        fetch = require("node-fetch").default;
+    } else if (typeof __non_webpack_require__ !== "undefined") {
+        // use a runtime 'require' call that is
+        // not parsed by webpack
+        // eslint-disable-next-line no-undef
+        fetch = __non_webpack_require__("node-fetch").default;
     }
 }
 

--- a/src/js/base/compat.js
+++ b/src/js/base/compat.js
@@ -80,7 +80,7 @@ if (
         // using a plain require call to load the module, since using
         // the webpack call will result in module not found by nuxt.js
         // applications
-        // eslint-disable-next-line camelcase
+        // eslint-disable-next-line no-undef
         XMLHttpRequest = __non_webpack_require__(correctModuleName).XMLHttpRequest;
     }
 }

--- a/src/js/base/compat.js
+++ b/src/js/base/compat.js
@@ -74,14 +74,12 @@ if (
     } else if (typeof window !== "undefined") {
         XMLHttpRequest = window.XMLHttpRequest;
         // eslint-disable-next-line camelcase
-    } else if (typeof require !== "undefined" && typeof __webpack_require__ !== "undefined") {
-        const mixedModuleName = "Xmlhttprequest";
-        const correctModuleName = mixedModuleName.toLowerCase();
+    } else if (typeof __webpack_require__ !== "undefined") {
         // using a plain require call to load the module, since using
         // the webpack call will result in module not found by nuxt.js
         // applications
         // eslint-disable-next-line no-undef
-        XMLHttpRequest = __non_webpack_require__(correctModuleName).XMLHttpRequest;
+        XMLHttpRequest = __non_webpack_require__("xmlhttprequest").XMLHttpRequest;
     }
 }
 
@@ -102,7 +100,8 @@ if (
         fetch = require("node-fetch").default;
     } else if (typeof window !== "undefined") {
         fetch = window.fetch;
-    } else if (typeof require !== "undefined") {
+        // eslint-disable-next-line camelcase
+    } else if (typeof __webpack_require__ !== "undefined") {
         fetch = require("node-fetch").default;
     }
 }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Closes #195 |
| Dependencies | -- |
| Decisions | Checks to see if it is using webpack and the window is not defined. If so, uses the npm packages. Uses `__non_webpack_require__` to import `xmlhttprequest`, which is not defined by the `webpack's require`. This allows for no configuration in the `ripe-sdk`'s clients, as well as almost no changes in the existing code. |
| References |  • https://github.com/webpack/webpack/issues/11455 <br> • https://stackoverflow.com/questions/46185302/non-webpack-require-is-not-defined <br> • https://stackoverflow.com/questions/42797313/webpack-dynamic-module-loader-by-require | 
| Animated GIF | `epir-papyrus` with sdk, build with `nuxt build --standalone` and `nuxt start`: <br> ![Sep-28-2020 13-27-37](https://user-images.githubusercontent.com/25725586/94432297-7aabdf00-018e-11eb-85ce-9ef5bf850a6a.gif) |