### PR TITLE
#202: Workaround for webpack static analysis of xmlhttprequst package import

### DIFF
--- a/src/js/base/compat.js
+++ b/src/js/base/compat.js
@@ -74,8 +74,12 @@ if (
         const correctModuleName = mixedModuleName.toLowerCase();
         XMLHttpRequest = require(correctModuleName).XMLHttpRequest;
     } else if (typeof __non_webpack_require__ !== "undefined") { // eslint-disable-line camelcase
+        // this is an hack to work around webpack static analysis when
+        // importing child_process, a dependency of xmlhttprequest
+        const mixedModuleName = "Xmlhttprequest";
+        const correctModuleName = mixedModuleName.toLowerCase();
         // eslint-disable-next-line no-undef
-        XMLHttpRequest = __non_webpack_require__("xmlhttprequest").XMLHttpRequest;
+        XMLHttpRequest = __non_webpack_require__(correctModuleName).XMLHttpRequest;
     }
 }
 

--- a/src/js/base/compat.js
+++ b/src/js/base/compat.js
@@ -73,13 +73,6 @@ if (
         const mixedModuleName = "Xmlhttprequest";
         const correctModuleName = mixedModuleName.toLowerCase();
         XMLHttpRequest = require(correctModuleName).XMLHttpRequest;
-    } else if (typeof __non_webpack_require__ !== "undefined") { // eslint-disable-line camelcase
-        // this is an hack to work around webpack static analysis when
-        // importing child_process, a dependency of xmlhttprequest
-        const mixedModuleName = "Xmlhttprequest";
-        const correctModuleName = mixedModuleName.toLowerCase();
-        // eslint-disable-next-line no-undef
-        XMLHttpRequest = __non_webpack_require__(correctModuleName).XMLHttpRequest;
     }
 }
 
@@ -100,9 +93,6 @@ if (
         (typeof navigator === "undefined" || navigator.product !== "ReactNative")
     ) {
         fetch = require("node-fetch").default;
-    } else if (typeof __non_webpack_require__ !== "undefined") { // eslint-disable-line camelcase
-        // eslint-disable-next-line no-undef
-        fetch = __non_webpack_require__("node-fetch").default;
     }
 }
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | #202 |
| Dependencies | -- |
| Decisions | Added workaround similar to react-native one, where the dependency name is assigned to a variable. However, it launches a warning `Critical dependency: the request of a dependency is an expression`.  The warning does not affect the build. <br> This fix does not require any change in the clients of the sdk. |
| Animated GIF | -- |
