### PR TITLE
Added text/plain contentType for response

### DIFF
--- a/src/js/base/api.js
+++ b/src/js/base/api.js
@@ -335,6 +335,8 @@ ripe.Ripe.prototype._requestURLFetch = function(url, options, callback) {
             try {
                 if (contentType.startsWith("application/json")) {
                     result = await response.json();
+                } else if (contentType.startsWith("text/plain")) {
+                    result = await response.text();
                 } else {
                     result = await response.blob();
                 }

--- a/src/js/base/api.js
+++ b/src/js/base/api.js
@@ -335,7 +335,7 @@ ripe.Ripe.prototype._requestURLFetch = function(url, options, callback) {
             try {
                 if (contentType.startsWith("application/json")) {
                     result = await response.json();
-                } else if (contentType.startsWith("text/plain")) {
+                } else if (contentType.startsWith("text/")) {
                     result = await response.text();
                 } else {
                     result = await response.blob();

--- a/test/js/api/brand.js
+++ b/test/js/api/brand.js
@@ -17,7 +17,7 @@ describe("BrandAPI", function() {
                 method: "minimum_initials"
             });
 
-            assert.strictEqual(await result.text(), "1");
+            assert.strictEqual(await result, "1");
 
             result = await remote.runLogicP({
                 brand: "dummy",
@@ -25,7 +25,7 @@ describe("BrandAPI", function() {
                 method: "maximum_initials"
             });
 
-            assert.strictEqual(await result.text(), "4");
+            assert.strictEqual(await result, "4");
         });
     });
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Derived from https://github.com/ripe-tech/ripe-compose/issues/84 |
| Dependencies | -- |
| Decisions | Support for `text/plain` response types without the need for `.text()` call. |
| Animated GIF | -- |
