### PR TITLE
#685 Add get bundle method

### DIFF
--- a/src/js/base/logic.js
+++ b/src/js/base/logic.js
@@ -17,6 +17,15 @@ if (
 }
 
 /**
+ * Gets the current bundle object.
+ *
+ * @returns {Object} The current bundle object.
+ */
+ripe.Ripe.prototype.getBundle = function() {
+    return LOCALES_BASE;
+};
+
+/**
  * Adds a new bundle object to the currently set of registered
  * bundles for the the given locale.
  *


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/685 <br> Currently there's no method to access the localesMap of Ripe SDK, only by translating keys using `localeLocal`. |
| Decisions |  This method will allow commons-pluginus to get localesMap of Ripe SDK which contains the scales and sizes translated versions as suiggested by https://github.com/ripe-tech/ripe-commons-pluginus/pull/180#issuecomment-731274901 |

