### PR TITLE
Small fix null brand and model when validating the models

### DIFF
--- a/src/js/api/brand.js
+++ b/src/js/api/brand.js
@@ -692,6 +692,8 @@ ripe.Ripe.prototype._getFactoryOptions = function(options = {}) {
 ripe.Ripe.prototype._validateModelOptions = function(options = {}) {
     const queryOptions = options.queryOptions === undefined ? true : options.queryOptions;
     const initialsOptions = options.initialsOptions === undefined ? true : options.initialsOptions;
+    const brand = options.brand === undefined ? this.brand : options.brand;
+    const model = options.model === undefined ? this.model : options.model;
     if (queryOptions) {
         // obtains the query options taking into account that the brand
         // and the model are not to be included in the parameters as they
@@ -702,8 +704,6 @@ ripe.Ripe.prototype._validateModelOptions = function(options = {}) {
     const gender = options.gender === undefined ? this.gender : options.gender;
     const size = options.size === undefined ? this.size : options.size;
     const parts = options.parts === undefined ? this.parts : options.parts;
-    const brand = options.brand === undefined ? this.brand : options.brand;
-    const model = options.model === undefined ? this.model : options.model;
     const url = `${this.url}brands/${brand}/models/${model}/validate`;
     const params = options.params || {};
     if (gender !== undefined && gender !== null) {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | The request URL when doing validateModelP will have null brand and model because `_getQueryOptions` will set null brand and model when doing [this](https://github.com/ripe-tech/ripe-sdk/blob/dbc04498e444ed443fb69aabdcb7b7578bced47a/src/js/api/brand.js#L699). ![image](https://user-images.githubusercontent.com/24736423/101390020-1dcd5300-38ba-11eb-8386-d109b12cdc50.png) |
| Decisions | Fix by setting brand and model vars before they're set to to null in the options. |
