### PR TITLE
#45: Configurator error on destroy

### DIFF
--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -624,11 +624,13 @@ ripe.ConfiguratorPrc.prototype.changeFrame = async function(frame, options = {})
  * @param {Object} options Set of optional parameters to adjust the highlighting.
  */
 ripe.ConfiguratorPrc.prototype.highlight = function(part, options = {}) {
+    // in case the element is no longer available (possible due to async
+    // nature of execution) returns the control flow immediately
+    if (!this.element) return;
+
     // verifiers if masks are meant to be used for the current model
     // and if that's not the case returns immediately
-    if (!this.useMasks) {
-        return;
-    }
+    if (!this.useMasks) return;
 
     // captures the current context to be used by clojure callbacks
     const self = this;
@@ -694,13 +696,13 @@ ripe.ConfiguratorPrc.prototype.highlight = function(part, options = {}) {
  * @param {Object} options Set of optional parameters to adjust the lowlighting.
  */
 ripe.ConfiguratorPrc.prototype.lowlight = function(options) {
+    // in case the element is no longer available (possible due to async
+    // nature of execution) returns the control flow immediately
     if (!this.element) return;
 
-    // verifiers if masks are meant to be used for the current model
+    // verifies if masks are meant to be used for the current model
     // and if that's not the case returns immediately
-    if (!this.useMasks) {
-        return;
-    }
+    if (!this.useMasks) return;
 
     // retrieves the reference to the current front mask and removes
     // the highlight associated classes from it and the configurator
@@ -794,9 +796,11 @@ ripe.ConfiguratorPrc.prototype.disableMasks = function() {
  * @private
  */
 ripe.ConfiguratorPrc.prototype._initLayout = function() {
+    // in case the element is no longer available (possible due to async
+    // nature of execution) returns the control flow immediately
     if (!this.element) return;
 
-    // clears the elements children
+    // clears the elements children by iterating over them
     while (this.element.firstChild) {
         this.element.removeChild(this.element.firstChild);
     }
@@ -873,6 +877,8 @@ ripe.ConfiguratorPrc.prototype._initPartsList = async function() {
  * @ignore
  */
 ripe.ConfiguratorPrc.prototype._populateBuffers = function() {
+    // in case the element is no longer available (possible due to async
+    // nature of execution) returns the control flow immediately
     if (!this.element) return;
 
     const framesBuffer = this.element.getElementsByClassName("frames-buffer");
@@ -914,6 +920,8 @@ ripe.ConfiguratorPrc.prototype._populateBuffer = function(buffer) {
  * @ignore
  */
 ripe.ConfiguratorPrc.prototype._updateConfig = async function(animate) {
+    // in case the element is no longer available (possible due to async
+    // nature of execution) returns the control flow immediately
     if (!this.element) return;
 
     // sets ready to false to temporarily block
@@ -1190,6 +1198,8 @@ ripe.ConfiguratorPrc.prototype._drawMask = function(maskImage) {
  * @ignore
  */
 ripe.ConfiguratorPrc.prototype._drawFrame = async function(image, animate, duration) {
+    // in case the element is no longer available (possible due to async
+    // nature of execution) returns the control flow immediately
     if (!this.element) return;
 
     const area = this.element.querySelector(".area");

--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -694,6 +694,8 @@ ripe.ConfiguratorPrc.prototype.highlight = function(part, options = {}) {
  * @param {Object} options Set of optional parameters to adjust the lowlighting.
  */
 ripe.ConfiguratorPrc.prototype.lowlight = function(options) {
+    if (!this.element) return;
+
     // verifiers if masks are meant to be used for the current model
     // and if that's not the case returns immediately
     if (!this.useMasks) {
@@ -792,6 +794,8 @@ ripe.ConfiguratorPrc.prototype.disableMasks = function() {
  * @private
  */
 ripe.ConfiguratorPrc.prototype._initLayout = function() {
+    if (!this.element) return;
+
     // clears the elements children
     while (this.element.firstChild) {
         this.element.removeChild(this.element.firstChild);
@@ -869,6 +873,8 @@ ripe.ConfiguratorPrc.prototype._initPartsList = async function() {
  * @ignore
  */
 ripe.ConfiguratorPrc.prototype._populateBuffers = function() {
+    if (!this.element) return;
+
     const framesBuffer = this.element.getElementsByClassName("frames-buffer");
     const masksBuffer = this.element.getElementsByClassName("masks-buffer");
     let buffer = null;
@@ -908,6 +914,8 @@ ripe.ConfiguratorPrc.prototype._populateBuffer = function(buffer) {
  * @ignore
  */
 ripe.ConfiguratorPrc.prototype._updateConfig = async function(animate) {
+    if (!this.element) return;
+
     // sets ready to false to temporarily block
     // update requests while the new config
     // is being loaded
@@ -1182,6 +1190,8 @@ ripe.ConfiguratorPrc.prototype._drawMask = function(maskImage) {
  * @ignore
  */
 ripe.ConfiguratorPrc.prototype._drawFrame = async function(image, animate, duration) {
+    if (!this.element) return;
+
     const area = this.element.querySelector(".area");
     const back = this.element.querySelector(".back");
 
@@ -1295,9 +1305,8 @@ ripe.ConfiguratorPrc.prototype._preload = async function(useChain) {
 
         const mark = element => {
             const _index = this.index;
-            if (index !== _index) {
-                return;
-            }
+            if (index !== _index) return;
+            if (!this.element) return;
 
             // removes the preloading class from the image element
             // and retrieves all the images still preloading,

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -581,8 +581,12 @@ ripe.Image.prototype._registerHandlers = function() {
  * @ignore
  */
 ripe.Image.prototype._unregisterHandlers = function() {
-    if (this.loadListener && this.element) this.element.removeEventListener("load", this.loadListener);
-    if (this.errorListener && this.element) this.element.removeEventListener("error", this.errorListener);
+    if (this.loadListener && this.element) {
+        this.element.removeEventListener("load", this.loadListener);
+    }
+    if (this.errorListener && this.element) {
+        this.element.removeEventListener("error", this.errorListener);
+    }
     if (this.loadedHandler) this.unbind("loaded", this.loadedHandler);
     if (this.errorHandler) this.unbind("error", this.errorHandler);
     if (this._observer) this._observer.disconnect();

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -248,6 +248,10 @@ ripe.Image.prototype.updateOptions = async function(options, update = true) {
  * @param {Object} options Set of optional parameters to adjust the Image.
  */
 ripe.Image.prototype.update = async function(state, options = {}) {
+    // in case the element is no longer available (possible due to async
+    // nature of execution) returns the control flow immediately
+    if (!this.element) return;
+
     // gathers the complete set of data values from the element if existent
     // defaulting to the instance one in case their are not defined
     const frame = this.element.dataset.frame || this.frame;
@@ -531,6 +535,8 @@ ripe.Image.prototype._doubleBuffer = async function(url) {
  * @ignore
  */
 ripe.Image.prototype._registerHandlers = function() {
+    if (!this.element) return;
+
     // creates and add both the load and the error listeners
     // for the underlying image element to propagate those events
     // into the current observable context (event normalization)
@@ -575,8 +581,8 @@ ripe.Image.prototype._registerHandlers = function() {
  * @ignore
  */
 ripe.Image.prototype._unregisterHandlers = function() {
-    if (this.loadListener) this.element.removeEventListener("load", this.loadListener);
-    if (this.errorListener) this.element.removeEventListener("error", this.errorListener);
+    if (this.loadListener && this.element) this.element.removeEventListener("load", this.loadListener);
+    if (this.errorListener && this.element) this.element.removeEventListener("error", this.errorListener);
     if (this.loadedHandler) this.unbind("loaded", this.loadedHandler);
     if (this.errorHandler) this.unbind("error", this.errorHandler);
     if (this._observer) this._observer.disconnect();


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-sdk-components-vue/issues/45 |
| Dependencies | -- |
| Decisions | Due to the async nature of the configurator and image execution, it is possible to initiate the destruction of a component that uses the configurator and images while they are updating their state. This would result in the `DOM element` not existing anymore and the components would try to access them, resulting in errors. The solution was returning the functions if the `element` was not defined.  |
| Animated GIF | Showing no errors when initiating and destroying components rapidly: ![destroy_configurator](https://user-images.githubusercontent.com/25725586/102105304-26c4a400-3e27-11eb-8e21-fa8806e57ef8.gif)|
