### PR TITLE
DataJ problem in _runLogicOptions

### DIFF
--- a/src/js/api/brand.js
+++ b/src/js/api/brand.js
@@ -770,6 +770,7 @@ ripe.Ripe.prototype._runLogicOptions = function(options = {}) {
     if (version !== undefined && version !== null) {
         params.version = version;
     }
+    delete options.data;
     return Object.assign(options, {
         url: url,
         method: "POST",

--- a/src/js/api/brand.js
+++ b/src/js/api/brand.js
@@ -764,18 +764,17 @@ ripe.Ripe.prototype._runLogicOptions = function(options = {}) {
     const model = options.model === undefined ? this.model : options.model;
     const version = options.version === undefined ? this.version : options.version;
     const method = options.method === undefined ? null : options.method;
-    const data = options.data === undefined ? null : options.data;
+    const dataJ = options.dataJ === undefined ? null : options.dataJ;
     const url = `${this.url}brands/${brand}/models/${model}/logic/${method}`;
     const params = {};
     if (version !== undefined && version !== null) {
         params.version = version;
     }
-    delete options.data;
     return Object.assign(options, {
         url: url,
         method: "POST",
         params: params,
-        dataJ: data
+        dataJ: dataJ
     });
 };
 

--- a/test/js/api/brand.js
+++ b/test/js/api/brand.js
@@ -81,12 +81,6 @@ describe("BrandAPI", function() {
             });
 
             assert.strictEqual(result, "4");
-        });
-
-        it("should execute a complex logic with context", async () => {
-            let result = null;
-
-            const remote = ripe.RipeAPI();
 
             result = await remote.runLogicP({
                 brand: "dummy",

--- a/test/js/api/brand.js
+++ b/test/js/api/brand.js
@@ -81,8 +81,12 @@ describe("BrandAPI", function() {
             });
 
             assert.strictEqual(result, "4");
+        });
 
-            result = await remote.runLogicP({
+        it("should execute a complex logic", async () => {
+            const remote = ripe.RipeAPI();
+
+            const result = await remote.runLogicP({
                 brand: "dummy",
                 model: "dummy",
                 method: "on_config",
@@ -112,7 +116,7 @@ describe("BrandAPI", function() {
     });
 
     describe("#onConfigP()", function() {
-        it("should execute a on_config logic", async () => {
+        it("should execute a complex logic", async () => {
             let result = null;
 
             const remote = ripe.RipeAPI();
@@ -147,7 +151,7 @@ describe("BrandAPI", function() {
     });
 
     describe("#onPartP()", function() {
-        it("should execute a on_part logic", async () => {
+        it("should execute a complex logic", async () => {
             let result = null;
 
             const remote = ripe.RipeAPI();
@@ -201,7 +205,7 @@ describe("BrandAPI", function() {
     });
 
     describe("#_getCombinationsOptions()", function() {
-        it("should include use_name as 0 by default", async () => {
+        it("should include `use_name` as 0 by default", async () => {
             let result = null;
 
             const remote = ripe.RipeAPI();
@@ -221,7 +225,7 @@ describe("BrandAPI", function() {
             assert.strictEqual(result.params.filter, "1");
         });
 
-        it("should include use_name as 1 when explicitly defined", async () => {
+        it("should include `use_name` as 1 when explicitly defined", async () => {
             let result = null;
 
             const remote = ripe.RipeAPI();

--- a/test/js/api/brand.js
+++ b/test/js/api/brand.js
@@ -82,6 +82,128 @@ describe("BrandAPI", function() {
 
             assert.strictEqual(result, "4");
         });
+
+        it("should execute a complex logic with context", async () => {
+            let result = null;
+
+            const remote = ripe.RipeAPI();
+
+            result = await remote.runLogicP({
+                brand: "dummy",
+                model: "dummy",
+                method: "on_config",
+                dataJ: {
+                    brand: "dummy",
+                    model: "dummy",
+                    ctx: {
+                        initials: {
+                            main: {
+                                initials: "AA",
+                                engraving: "style:black"
+                            }
+                        }
+                    }
+                }
+            });
+
+            assert.deepStrictEqual(result, {
+                initials: {
+                    main: {
+                        initials: "ST",
+                        engraving: "default"
+                    }
+                }
+            });
+        });
+    });
+
+    describe("#onConfigP()", function() {
+        it("should execute a on_config logic", async () => {
+            let result = null;
+
+            const remote = ripe.RipeAPI();
+
+            result = await remote.onConfigP({
+                brand: "dummy",
+                model: "dummy",
+                initials: {
+                    main: {
+                        initials: "AA",
+                        engraving: "style:black"
+                    }
+                },
+                parts: {},
+                choices: {}
+            });
+
+            assert.deepStrictEqual(result, {
+                brand: "dummy",
+                model: "dummy",
+                version: null,
+                initials: {
+                    main: {
+                        initials: "ST",
+                        engraving: "default"
+                    }
+                },
+                parts: {},
+                choices: {}
+            });
+        });
+    });
+
+    describe("#onPartP()", function() {
+        it("should execute a on_part logic", async () => {
+            let result = null;
+
+            const remote = ripe.RipeAPI();
+
+            result = await remote.onPartP({
+                brand: "dummy",
+                model: "dummy",
+                name: "side",
+                value: {
+                    material: "suede_dmy",
+                    color: "blue"
+                },
+                initials: {
+                    main: {
+                        initials: "AA",
+                        engraving: "style:black"
+                    }
+                },
+                parts: {
+                    side: {
+                        material: "suede_dmy",
+                        color: "blue"
+                    }
+                },
+                choices: {}
+            });
+
+            assert.deepStrictEqual(result, {
+                brand: "dummy",
+                model: "dummy",
+                version: null,
+                initials: {
+                    main: {
+                        initials: "DM",
+                        engraving: "default"
+                    }
+                },
+                parts: {
+                    side: {
+                        material: "leather_dmy",
+                        color: "black"
+                    }
+                },
+                choices: {},
+                messages: [
+                    ["config", "Colors forced to black"],
+                    ["config", "Shadow forced to default"]
+                ]
+            });
+        });
     });
 
     describe("#_getCombinationsOptions()", function() {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | The problem mentioned in the daily, that when passing the context or other options as `data` to the `runLogicP` method, that data does not reach `ripe-core`. |
| Dependencies | -- |
| Decisions | The problem was that both fields `data` and `dataJ` where being passed to yonius. Yonius ignores the `dataJ` if `data` is defined, and adds the `data` to the URL as parameters (as expected), instead of sending it in the request body <br> https://github.com/hivesolutions/yonius/blob/b952ad890b82123009b735e3cdc8c467c9b195b8/js/api/api.js#L119 <br> It is necessary to delete the `data` field when creating the request. Tested by making request, the data is now reaching `ripe-core` and being passed to the method in the model logic script. |
| Animated GIF | -- |
