### PR TITLE
Add missing params to configInfo

### DIFF
--- a/src/js/api/config.js
+++ b/src/js/api/config.js
@@ -251,6 +251,10 @@ ripe.Ripe.prototype._getConfigInfoOptions = function(options = {}) {
     const domain = options.domain === undefined ? null : options.domain;
     const dku = options.dku === undefined ? null : options.dku;
     const guess = options.guess === undefined ? this.guess : options.guess;
+    const size = options.size === undefined ? this.size : options.size;
+    const gender = options.gender === undefined ? this.gender : options.gender;
+    const meta = options.meta === undefined ? this.meta : options.meta;
+    const _params = options._params === undefined ? this._params : options._params;
     const queryOptions = options.queryOptions === undefined ? true : options.queryOptions;
     const initialsOptions = options.initialsOptions === undefined ? true : options.initialsOptions;
 
@@ -271,6 +275,18 @@ ripe.Ripe.prototype._getConfigInfoOptions = function(options = {}) {
     }
     if (guess !== undefined && guess !== null) {
         params.guess = guess ? "1" : "0";
+    }
+    if (size !== undefined && size !== null) {
+        params.size = size;
+    }
+    if (gender !== undefined && gender !== null) {
+        params.gender = gender;
+    }
+    if (meta !== undefined && meta !== null) {
+        params.meta = meta;
+    }
+    if (_params !== undefined && _params !== null) {
+        params.params = _params;
     }
 
     const url = `${this.url}config/info`;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/3db/issues/46#issuecomment-749085566 |
| Dependencies | |
| Decisions | Based on https://github.com/ripe-tech/ripe-core/blob/107411b442473779b0fd6003823cddc139057796/src/ripe_core/controllers/api/config.py#L22. <br/> The [docs](https://docs.platforme.com/#config-endpoints-info) are outdated. <br/> Used `_params` to avoid collision with `params` which means a different thing (request params rather than a param named `params`) |

