### PR TITLE
docs: fix inconsistencies

### DIFF
--- a/src/js/api/availability-rule.js
+++ b/src/js/api/availability-rule.js
@@ -15,7 +15,7 @@ if (
  * Gets the existing availability rules, according to the provided filtering
  * strategy as normalized values.
  *
- * @param {Object} options An object of options to configure the request
+ * @param {Object} options An object of options to configure the request.
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
  */
@@ -51,8 +51,8 @@ ripe.Ripe.prototype.getAvailabilityRulesP = function(options) {
  * Gets an existing availability rule filtered by ID and according to the
  * provided filtering strategy as normalized values.
  *
- * @param {Number} id The Availability Rule's ID.
- * @param {Object} options An object of options to configure the request
+ * @param {Number} id The availability rule's ID.
+ * @param {Object} options An object of options to configure the request.
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
  */
@@ -73,9 +73,9 @@ ripe.Ripe.prototype.getAvailabilityRule = function(id, options, callback) {
  * Gets an existing availability rule filtered by ID and according to the
  * provided filtering strategy as normalized values.
  *
- * @param {Number} id The Availability Rule's ID.
- * @param {Object} options An object of options to configure the request
- * @returns {Promise} The availability rules list.
+ * @param {Number} id The availability rule's ID.
+ * @param {Object} options An object of options to configure the request.
+ * @returns {Promise} The availability rule requested by ID.
  */
 ripe.Ripe.prototype.getAvailabilityRuleP = function(id, options) {
     return new Promise((resolve, reject) => {
@@ -86,10 +86,10 @@ ripe.Ripe.prototype.getAvailabilityRuleP = function(id, options) {
 };
 
 /**
- * Creates a Availability Rule on RIPE Core.
+ * Creates an availability rule on RIPE Core.
  *
- * @param {Object} availabilityRule The Availability Rule object
- * @param {Object} options An object with options
+ * @param {Object} availabilityRule The availability rule data.
+ * @param {Object} options An object with options.
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} Resulting information for the callback execution.
  */
@@ -108,10 +108,10 @@ ripe.Ripe.prototype.createAvailabilityRule = function(availabilityRule, options,
 };
 
 /**
- * Creates a Availability Rule on RIPE Core.
+ * Creates an availability rule on RIPE Core.
  *
- * @param {Object} availabilityRule The Availability Rule object
- * @param {Object} options An object with options
+ * @param {Object} availabilityRule The availability rule's data.
+ * @param {Object} options An object with options.
  * @returns {Promise} The availability rule's data.
  */
 ripe.Ripe.prototype.createAvailabilityRuleP = function(availabilityRule, options) {
@@ -123,9 +123,9 @@ ripe.Ripe.prototype.createAvailabilityRuleP = function(availabilityRule, options
 };
 
 /**
- * Updates a Availability Rule on RIPE Core.
+ * Updates an availability rule on RIPE Core.
  *
- * @param {Object} availabilityRule The Availability Rule object
+ * @param {Object} availabilityRule The availability rule's data.
  * @param {Object} options An object of options to configure the request
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} Resulting information for the callback execution.
@@ -145,11 +145,11 @@ ripe.Ripe.prototype.updateAvailabilityRule = function(availabilityRule, options,
 };
 
 /**
- * Updates a Availability Rule on RIPE Core.
+ * Updates an availability rule on RIPE Core.
  *
- * @param {Object} availabilityRule The Availability Rule object
- * @param {Object} options An object of options to configure the request
- * @returns {Promise} The Availability Rule's data.
+ * @param {Object} availabilityRule The Availability Rule's data.
+ * @param {Object} options An object of options to configure the request.
+ * @returns {Promise} The availability rule's data.
  */
 ripe.Ripe.prototype.updateAvailabilityRuleP = function(availabilityRule, options) {
     return new Promise((resolve, reject) => {
@@ -160,10 +160,9 @@ ripe.Ripe.prototype.updateAvailabilityRuleP = function(availabilityRule, options
 };
 
 /**
- * Deletes the existing availability rules filtered by ID, according to the
- * provided filtering strategy as normalized values.
+ * Deletes an existing availability rule.
  *
- * @param {Number} id The Availability Rule's ID.
+ * @param {Number} id The availability rule's ID.
  * @param {Object} options An object of options to configure the request
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
@@ -182,12 +181,11 @@ ripe.Ripe.prototype.deleteAvailabilityRule = function(id, options, callback) {
 };
 
 /**
- * Deletes the existing availability rules filtered by ID, according to the
- * provided filtering strategy as normalized values.
+ * Deletes an existing availability rule.
  *
- * @param {Number} id The Availability Rule's ID.
+ * @param {Number} id The availability rule's ID.
  * @param {Object} options An object of options to configure the request
- * @returns {Promise} The availability rules list.
+ * @returns {Promise} The result of the availability rule's deletion.
  */
 ripe.Ripe.prototype.deleteAvailabilityRuleP = function(id, options) {
     return new Promise((resolve, reject) => {

--- a/src/js/api/brand.js
+++ b/src/js/api/brand.js
@@ -15,11 +15,11 @@ if (
  * Returns the logo of a brand.
  *
  * @param {Object} options A map with options, such as:
- *  - 'brand' - The brand of the model
- *  - 'version' - The version of the build, defaults to latest
- *  - 'variant' - The variant of the logo, that controls semantics of the logo
- *  - 'format' - The format of the logo image to be retrieved (defaults to 'png')
- *  - 'size' - The size of the logo image
+ *  - 'brand' - The brand of the model.
+ *  - 'version' - The version of the build, defaults to latest.
+ *  - 'variant' - The variant of the logo, that controls semantics of the logo.
+ *  - 'format' - The format of the logo image to be retrieved (defaults to 'png').
+ *  - 'size' - The size of the logo image.
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} The brand's logo.
  */
@@ -35,11 +35,11 @@ ripe.Ripe.prototype.getLogo = function(options, callback) {
  * Returns the logo of a brand.
  *
  * @param {Object} options A map with options, such as:
- *  - 'brand' - The brand of the model
- *  - 'version' - The version of the build, defaults to latest
- *  - 'variant' - The variant of the logo, that controls semantics of the logo
- *  - 'format' - The format of the logo image to be retrieved (defaults to 'png')
- *  - 'size' - The size of the logo image
+ *  - 'brand' - The brand of the model.
+ *  - 'version' - The version of the build, defaults to latest.
+ *  - 'variant' - The variant of the logo, that controls semantics of the logo.
+ *  - 'format' - The format of the logo image to be retrieved (defaults to 'png').
+ *  - 'size' - The size of the logo image.
  * @returns {Promise} The brand's logo.
  */
 ripe.Ripe.prototype.getLogoP = function(options) {
@@ -57,10 +57,10 @@ ripe.Ripe.prototype.getLogoP = function(options) {
  * image user their own loading infrastructure.
  *
  * @param {Object} options A map with options, such as:
- *  - 'brand' - The brand of the model
- *  - 'version' - The version of the build, defaults to latest
- *  - 'variant' - The variant of the logo, that controls semantics of the logo
- *  - 'format' - The format of the logo image to be retrieved (defaults to 'png')
+ *  - 'brand' - The brand of the model.
+ *  - 'version' - The version of the build, defaults to latest.
+ *  - 'variant' - The variant of the logo, that controls semantics of the logo.
+ *  - 'format' - The format of the logo image to be retrieved (defaults to 'png').
  * @returns {String} The URL that can be used to retrieve a brand logo.
  */
 ripe.Ripe.prototype.getLogoUrl = function(options) {
@@ -72,10 +72,10 @@ ripe.Ripe.prototype.getLogoUrl = function(options) {
  * Returns the mesh contents for a model.
  *
  * @param {Object} options A map with options, such as:
- *  - 'brand' - The brand of the model
- *  - 'model' - The name of the model
- *  - 'version' - The version of the build, defaults to latest
- *  - 'variant' - The variant of the mesh, as defined in the model spec
+ *  - 'brand' - The brand of the model.
+ *  - 'model' - The name of the model.
+ *  - 'version' - The version of the build, defaults to latest.
+ *  - 'variant' - The variant of the mesh, as defined in the model spec.
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} The model's mesh.
  */
@@ -91,10 +91,10 @@ ripe.Ripe.prototype.getMesh = function(options, callback) {
  * Returns the mesh contents for a model.
  *
  * @param {Object} options A map with options, such as:
- *  - 'brand' - The brand of the model
- *  - 'model' - The name of the model
- *  - 'version' - The version of the build, defaults to latest
- *  - 'variant' - The variant of the mesh, as defined in the model spec
+ *  - 'brand' - The brand of the model.
+ *  - 'model' - The name of the model.
+ *  - 'version' - The version of the build, defaults to latest.
+ *  - 'variant' - The variant of the mesh, as defined in the model spec.
  * @returns {XMLHttpRequest} The model's mesh.
  */
 ripe.Ripe.prototype.getMeshP = function(options) {
@@ -112,10 +112,10 @@ ripe.Ripe.prototype.getMeshP = function(options) {
  * take control of the URL based mesh loading process.
  *
  * @param {Object} options A map with options, such as:
- *  - 'brand' - The brand of the model
- *  - 'model' - The name of the model
- *  - 'version' - The version of the build, defaults to latest
- *  - 'variant' - The variant of the mesh, as defined in the model spec
+ *  - 'brand' - The brand of the model.
+ *  - 'model' - The name of the model.
+ *  - 'version' - The version of the build, defaults to latest.
+ *  - 'variant' - The variant of the mesh, as defined in the model spec.
  * @returns {String} The URL that can be used to retrieve the mesh.
  */
 ripe.Ripe.prototype.getMeshUrl = function(options) {
@@ -128,12 +128,12 @@ ripe.Ripe.prototype.getMeshUrl = function(options) {
  * If no model is provided then returns the information of the owner's current model.
  *
  * @param {Object} options A map with options, such as:
- *  - 'brand' - The brand of the model
- *  - 'model' - The name of the model
- *  - 'version' - The version of the build, defaults to latest
- *  - 'country' - The country where the model will be provided, some materials/colors might not be available
- *  - 'flag' - A specific flag that may change the provided materials/colors available
- *  - 'filter' - If the configuration should be filtered by the country and/or flag (defaults to 'true')
+ *  - 'brand' - The brand of the model.
+ *  - 'model' - The name of the model.
+ *  - 'version' - The version of the build, defaults to latest.
+ *  - 'country' - The country where the model will be provided, some materials/colors might not be available.
+ *  - 'flag' - A specific flag that may change the provided materials/colors available.
+ *  - 'filter' - If the configuration should be filtered by the country and/or flag (defaults to 'true').
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} The model's configuration data.
  */
@@ -150,12 +150,12 @@ ripe.Ripe.prototype.getConfig = function(options, callback) {
  * If no model is provided then returns the information of the owner's current model.
  *
  * @param {Object} options An object with options, such as:
- *  - 'brand' - The brand of the model
- *  - 'model' - The name of the model
- *  - 'version' - The version of the build, defaults to latest
- *  - 'country' - The country where the model will be provided, some materials/colors might not be available
- *  - 'flag' - A specific flag that may change the provided materials/colors available
- *  - 'filter' - If the configuration should be filtered by the country and/or flag (defaults to 'true')
+ *  - 'brand' - The brand of the model.
+ *  - 'model' - The name of the model.
+ *  - 'version' - The version of the build, defaults to latest.
+ *  - 'country' - The country where the model will be provided, some materials/colors might not be available.
+ *  - 'flag' - A specific flag that may change the provided materials/colors available.
+ *  - 'filter' - If the configuration should be filtered by the country and/or flag (defaults to 'true').
  * @returns {Promise} The model's configuration data.
  */
 ripe.Ripe.prototype.getConfigP = function(options) {
@@ -171,9 +171,9 @@ ripe.Ripe.prototype.getConfigP = function(options) {
  * then returns the defaults of the owner's current model.
  *
  * @param {Object} options An object with options, such as:
- *  - 'brand' - The brand of the model
- *  - 'model' - The name of the model
- *  - 'version' - The version of the build, defaults to latest
+ *  - 'brand' - The brand of the model.
+ *  - 'model' - The name of the model.
+ *  - 'version' - The version of the build, defaults to latest.
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} The model's default options.
  */
@@ -192,9 +192,9 @@ ripe.Ripe.prototype.getDefaults = function(options, callback) {
  * If no model is provided then returns the defaults of the owner's current model.
  *
  * @param {Object} options An object with options, such as:
- *  - 'brand' - The brand of the model
- *  - 'model' - The name of the model
- *  - 'version' - The version of the build, defaults to latest
+ *  - 'brand' - The brand of the model.
+ *  - 'model' - The name of the model.
+ *  - 'version' - The version of the build, defaults to latest.
  * @param {Function} callback Function with the result of the request.
  * @returns {Object} The model's optional parts.
  */
@@ -214,9 +214,9 @@ ripe.Ripe.prototype.getOptionals = function(options, callback) {
  * If no model is provided then returns the defaults of the owner's current model.
  *
  * @param {Object} options An object with options, such as:
- *  - 'brand' - The brand of the model
- *  - 'model' - The name of the model
- *  - 'version' - The version of the build, defaults to latest
+ *  - 'brand' - The brand of the model.
+ *  - 'model' - The name of the model.
+ *  - 'version' - The version of the build, defaults to latest.
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} The model's total set of combinations.
  */
@@ -235,9 +235,9 @@ ripe.Ripe.prototype.getCombinations = function(options, callback) {
  * If no model is provided then returns the defaults of the owner's current model.
  *
  * @param {Object} options An object with options, such as:
- *  - 'brand' - The brand of the model
- *  - 'model' - The name of the model
- *  - 'version' - The version of the build, defaults to latest
+ *  - 'brand' - The brand of the model.
+ *  - 'model' - The name of the model.
+ *  - 'version' - The version of the build, defaults to latest.
  * @returns {Promise} The model's total set of combinations.
  */
 ripe.Ripe.prototype.getCombinationsP = function(options) {
@@ -254,8 +254,8 @@ ripe.Ripe.prototype.getCombinationsP = function(options) {
  * If no model is provided then returns the defaults of the owner's current model.
  *
  * @param {Object} options An object with options, such as:
- *  - 'brand' - The brand of the model
- *  - 'model' - The name of the model
+ *  - 'brand' - The brand of the model.
+ *  - 'model' - The name of the model.
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} The factory information for the provided model.
  */
@@ -273,8 +273,8 @@ ripe.Ripe.prototype.getFactory = function(options, callback) {
  * If no model is provided then returns the defaults of the owner's current model.
  *
  * @param {Object} options An object with options, such as:
- *  - 'brand' - The brand of the model
- *  - 'model' - The name of the model
+ *  - 'brand' - The brand of the model.
+ *  - 'model' - The name of the model.
  * @param {Function} callback Function with the result of the request.
  * @returns {Promise} The factory information for the provided model.
  */
@@ -291,12 +291,12 @@ ripe.Ripe.prototype.getFactoryP = function(options) {
  * considering a given build's brand, model and version.
  *
  * @param {Object} options An object with options, such as:
- *  - 'brand' - The name of the brand to be considered when validating
- *  - 'model' - The name of the model to be considered when validating
- *  - 'version' - The target build version to be considered when validating
- *  - 'parts' - The parts to be validated
- *  - 'engraving' - The engraving value to be validated
- *  - 'size' - The size to be validated
+ *  - 'brand' - The name of the brand to be considered when validating.
+ *  - 'model' - The name of the model to be considered when validating.
+ *  - 'version' - The target build version to be considered when validating.
+ *  - 'parts' - The parts to be validated.
+ *  - 'engraving' - The engraving value to be validated.
+ *  - 'size' - The size to be validated.
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} Resulting information for the callback execution.
  */
@@ -313,12 +313,12 @@ ripe.Ripe.prototype.validateModel = function(options, callback) {
  * considering a given build's brand, model and version.
  *
  * @param {Object} options An object with options, such as:
- *  - 'brand' - The name of the brand to be considered when validating
- *  - 'model' - The name of the model to be considered when validating
- *  - 'version' - The target build version to be considered when validating
- *  - 'parts' - The parts to be validated
- *  - 'engraving' - The engraving value to be validated
- *  - 'size' - The size to be validated
+ *  - 'brand' - The name of the brand to be considered when validating.
+ *  - 'model' - The name of the model to be considered when validating.
+ *  - 'version' - The target build version to be considered when validating.
+ *  - 'parts' - The parts to be validated.
+ *  - 'engraving' - The engraving value to be validated.
+ *  - 'size' - The size to be validated.
  * @returns {Promise} Resulting information for the callback execution.
  */
 ripe.Ripe.prototype.validateModelP = function(options) {
@@ -333,12 +333,12 @@ ripe.Ripe.prototype.validateModelP = function(options) {
  * Returns the logic script of a model in the requested format (javascript or python).
  *
  * @param {Object} options An object with options, such as:
- *  - 'brand' - The brand of the model
- *  - 'model' - The name of the model
- *  - 'version' - The version of the build, defaults to latest
- *  - 'format' - The format of the logic script ("js" or "py")
- *  - 'method' - The method of the logic module of the model
- *  - 'args' - The arguments to pass to the method, as an object
+ *  - 'brand' - The brand of the model.
+ *  - 'model' - The name of the model.
+ *  - 'version' - The version of the build, defaults to latest.
+ *  - 'format' - The format of the logic script ("js" or "py").
+ *  - 'method' - The method of the logic module of the model.
+ *  - 'args' - The arguments to pass to the method, as an object.
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} The logic script of the provided model.
  */
@@ -354,12 +354,12 @@ ripe.Ripe.prototype.getLogic = function(options, callback) {
  * Returns the logic script of a model in the requested format (javascript or python).
  *
  * @param {Object} options An object with options, such as:
- *  - 'brand' - The brand of the model
- *  - 'model' - The name of the model
- *  - 'version' - The version of the build, defaults to latest
- *  - 'format' - The format of the logic script ("js" or "py")
- *  - 'method' - The method of the logic module of the model
- *  - 'args' - The arguments to pass to the method, as an object
+ *  - 'brand' - The brand of the model.
+ *  - 'model' - The name of the model.
+ *  - 'version' - The version of the build, defaults to latest.
+ *  - 'format' - The format of the logic script ("js" or "py").
+ *  - 'method' - The method of the logic module of the model.
+ *  - 'args' - The arguments to pass to the method, as an object.
  * @returns {Promise} The logic script of the provided model.
  */
 ripe.Ripe.prototype.getLogicP = function(options) {
@@ -377,11 +377,11 @@ ripe.Ripe.prototype.getLogicP = function(options) {
  * a proper "sandboxed" environment.
  *
  * @param {Object} options An object with options, such as:
- *  - 'brand' - The brand of the model
- *  - 'model' - The name of the model
- *  - 'version' - The version of the build, defaults to latest
- *  - 'method' - The method of the logic module of the model
- *  - 'data' - The arguments to pass to the method
+ *  - 'brand' - The brand of the model.
+ *  - 'model' - The name of the model.
+ *  - 'version' - The version of the build, defaults to latest.
+ *  - 'method' - The method of the logic module of the model.
+ *  - 'data' - The arguments to pass to the method.
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} The result of the logic function of the provided model.
  */
@@ -400,11 +400,11 @@ ripe.Ripe.prototype.runLogic = function(options, callback) {
  * a proper "sandboxed" environment.
  *
  * @param {Object} options An object with options, such as:
- *  - 'brand' - The brand of the model
- *  - 'model' - The name of the model
- *  - 'version' - The version of the build, defaults to latest
- *  - 'method' - The method of the logic module of the model
- *  - 'data' - The arguments to pass to the method
+ *  - 'brand' - The brand of the model.
+ *  - 'model' - The name of the model.
+ *  - 'version' - The version of the build, defaults to latest.
+ *  - 'method' - The method of the logic module of the model.
+ *  - 'data' - The arguments to pass to the method.
  * @returns {Promise} The result of the logic function of the provided model.
  */
 ripe.Ripe.prototype.runLogicP = function(options) {
@@ -422,8 +422,8 @@ ripe.Ripe.prototype.runLogicP = function(options) {
  * a server side implementation of the 3DB's business logic.
  *
  * @param {Object} options An object with options, such as:
- *  - 'brand' - The brand of the model
- *  - 'model' - The name of the model
+ *  - 'brand' - The brand of the model.
+ *  - 'model' - The name of the model.
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} Resulting information for the callback execution.
  */
@@ -442,8 +442,8 @@ ripe.Ripe.prototype.onConfig = function(options, callback) {
  * a server side implementation of the 3DB's business logic.
  *
  * @param {Object} options An object with options, such as:
- *  - 'brand' - The brand of the model
- *  - 'model' - The name of the model
+ *  - 'brand' - The brand of the model.
+ *  - 'model' - The name of the model.
  * @returns {Promise} Resulting information for the callback execution.
  */
 ripe.Ripe.prototype.onConfigP = function(options) {
@@ -461,8 +461,8 @@ ripe.Ripe.prototype.onConfigP = function(options) {
  * a server side implementation of the 3DB's business logic.
  *
  * @param {Object} options An object with options, such as:
- *  - 'name' - The name of the part to be changed
- *  - 'value' - The value (material and color) of the part to be changed
+ *  - 'name' - The name of the part to be changed.
+ *  - 'value' - The value (material and color) of the part to be changed.
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} Resulting information for the callback execution.
  */
@@ -481,8 +481,8 @@ ripe.Ripe.prototype.onPart = function(options, callback) {
  * a server side implementation of the 3DB's business logic.
  *
  * @param {Object} options An object with options, such as:
- *  - 'name' - The name of the part to be changed
- *  - 'value' - The value (material and color) of the part to be changed
+ *  - 'name' - The name of the part to be changed.
+ *  - 'value' - The value (material and color) of the part to be changed.
  * @returns {Promise} Resulting information for the callback execution.
  */
 ripe.Ripe.prototype.onPartP = function(options) {
@@ -500,9 +500,9 @@ ripe.Ripe.prototype.onPartP = function(options) {
  * a server side implementation of the 3DB's business logic.
  *
  * @param {Object} options An object with options, such as:
- *  - 'group' - The name of the group that is going to be changed
- *  - 'value' - The initials value to be changed
- *  - 'engraving' - The engraving value to be changed
+ *  - 'group' - The name of the group that is going to be changed.
+ *  - 'value' - The initials value to be changed.
+ *  - 'engraving' - The engraving value to be changed.
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} Resulting information for the callback execution.
  */
@@ -521,9 +521,9 @@ ripe.Ripe.prototype.onInitials = function(options, callback) {
  * a server side implementation of the 3DB's business logic.
  *
  * @param {Object} options An object with options, such as:
- *  - 'group' - The name of the group that is going to be changed
- *  - 'value' - The initials value to be changed
- *  - 'engraving' - The engraving value to be changed
+ *  - 'group' - The name of the group that is going to be changed.
+ *  - 'value' - The initials value to be changed.
+ *  - 'engraving' - The engraving value to be changed.
  * @returns {Promise} Resulting information for the callback execution.
  */
 ripe.Ripe.prototype.onInitialsP = function(options) {

--- a/src/js/api/country-group.js
+++ b/src/js/api/country-group.js
@@ -24,7 +24,6 @@ if (
  * - 'skip' - The number of the first record to retrieve from the results.
  * - 'limit' - The number of results to retrieve.
  * @param {Function} callback Function with the result of the request.
- * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
  */
 ripe.Ripe.prototype.getCountryGroups = function(options, callback) {
@@ -56,11 +55,10 @@ ripe.Ripe.prototype.getCountryGroupsP = function(options) {
 };
 
 /**
- * Gets a country group by its id.
+ * Gets a country group by its ID.
  *
- * @param {Object} id Id of the intended country group.
+ * @param {Object} id ID of the intended country group.
  * @param {Object} options An object of options to configure the request.
- * @param {Function} callback Function with the result of the request.
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
  */
@@ -78,11 +76,11 @@ ripe.Ripe.prototype.getCountryGroup = function(id, options, callback) {
 };
 
 /**
- * Gets a country group by its id.
+ * Gets a country group by its ID.
  *
- * @param {Object} id Id of the intended country group.
+ * @param {Object} id ID of the intended country group.
  * @param {Object} options An object of options to configure the request.
- * @returns {Promise} The country group result list.
+ * @returns {Promise} The country group requested by ID.
  */
 ripe.Ripe.prototype.getCountryGroupP = function(id, options) {
     return new Promise((resolve, reject) => {
@@ -95,9 +93,9 @@ ripe.Ripe.prototype.getCountryGroupP = function(id, options) {
 /**
  * Creates a new country group.
  *
- * @param {Object} countryGroup An object with information needed to create a country group ex: {name: "Europe 1", currency: "EUR", countries: ["Portugal, Spain, France"]}.
+ * @param {Object} countryGroup An object with information needed to create a country group
+ * ex:{name: "Europe 1", currency: "EUR", countries: ["Portugal, Spain, France"]}.
  * @param {Object} options An object of options to configure the request.
- * @param {Function} callback Function with the result of the request.
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
  */
@@ -118,9 +116,10 @@ ripe.Ripe.prototype.createCountryGroup = function(countryGroup, options, callbac
 /**
  * Creates a new country group.
  *
- * @param {Object} countryGroup An object with information needed to create a country group ex: {name: "Europe 1", currency: "EUR", countries: ["Portugal, Spain, France"]}.
+ * @param {Object} countryGroup An object with information needed to create a country group
+ * ex: {name: "Europe 1", currency: "EUR", countries: ["Portugal, Spain, France"]}.
  * @param {Object} options An object of options to configure the request.
- * @returns {Promise} The country group result list.
+ * @returns {Promise} The country group's data.
  */
 ripe.Ripe.prototype.createCountryGroupP = function(countryGroup, options) {
     return new Promise((resolve, reject) => {
@@ -133,10 +132,9 @@ ripe.Ripe.prototype.createCountryGroupP = function(countryGroup, options) {
 /**
  * Updates an existing country group.
  *
- * @param {Object} id Id of the country group to be updated.
+ * @param {Object} id ID of the country group to be updated.
  * @param {Object} countryGroup An object with the updated information of the country group.
  * @param {Object} options An object of options to configure the request.
- * @param {Function} callback Function with the result of the request.
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
  */
@@ -157,10 +155,10 @@ ripe.Ripe.prototype.updateCountryGroup = function(id, countryGroup, options, cal
 /**
  * Updates an existing country group.
  *
- * @param {Object} id Id of the country group to be updated.
+ * @param {Object} id ID of the country group to be updated.
  * @param {Object} countryGroup An object with the updated information of the country group.
  * @param {Object} options An object of options to configure the request.
- * @returns {Promise} The country group result list.
+ * @returns {Promise} The country group's data.
  */
 ripe.Ripe.prototype.updateCountryGroupP = function(id, countryGroup, options) {
     return new Promise((resolve, reject) => {
@@ -173,9 +171,8 @@ ripe.Ripe.prototype.updateCountryGroupP = function(id, countryGroup, options) {
 /**
  * Deletes an existing country group.
  *
- * @param {Object} id Id of the country group to be deleted.
+ * @param {Object} id ID of the country group to be deleted.
  * @param {Object} options An object of options to configure the request.
- * @param {Function} callback Function with the result of the request.
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
  */
@@ -195,9 +192,9 @@ ripe.Ripe.prototype.deleteCountryGroup = function(id, options, callback) {
 /**
  * Deletes an existing country group.
  *
- * @param {Object} id Id of the country group to be deleted.
+ * @param {Object} id ID of the country group to be deleted.
  * @param {Object} options An object of options to configure the request.
- * @returns {Promise} The country group result list.
+ * @returns {Promise} The result of the country group's deletion.
  */
 ripe.Ripe.prototype.deleteCountryGroupP = function(id, options) {
     return new Promise((resolve, reject) => {

--- a/src/js/api/letter-rule.js
+++ b/src/js/api/letter-rule.js
@@ -15,7 +15,7 @@ if (
  * Gets the existing letter rules, according to the provided filtering
  * strategy as normalized values.
  *
- * @param {Object} options An object of options to configure the request
+ * @param {Object} options An object of options to configure the request.
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
  */

--- a/src/js/api/notify-info.js
+++ b/src/js/api/notify-info.js
@@ -13,7 +13,7 @@ if (
 
 /**
  * Creates a notify info (if required) for the current user, and adds
- * the provided device id to the list of device ids in the notify info.
+ * the provided device ID to the list of device ids in the notify info.
  *
  * @param {String} deviceId The device identifier as a plain string
  * to be used in registration.
@@ -35,7 +35,7 @@ ripe.Ripe.prototype.createDeviceId = function(deviceId, options, callback) {
 
 /**
  * Creates a notify info (if required) for the current user, and adds
- * the provided device id to the list of device ids in the notify info.
+ * the provided device ID to the list of device ids in the notify info.
  *
  * @param {String} deviceId The device identifier as a plain string
  * to be used in registration.
@@ -50,7 +50,7 @@ ripe.Ripe.prototype.createDeviceIdP = function(deviceId, options) {
 };
 
 /**
- * Removes a device id from the the notify info instance associated
+ * Removes a device ID from the the notify info instance associated
  * with the user in session.
  *
  * @param {String} deviceId The device identifier to be removed.
@@ -71,7 +71,7 @@ ripe.Ripe.prototype.removeDeviceId = function(deviceId, options, callback) {
 };
 
 /**
- * Removes a device id from the the notify info instance associated
+ * Removes a device ID from the the notify info instance associated
  * with the user in session.
  *
  * @param {String} deviceId The device identifier to be removed.

--- a/src/js/api/price-rule.js
+++ b/src/js/api/price-rule.js
@@ -15,7 +15,7 @@ if (
  * Gets the existing price rules, according to the provided filtering
  * strategy as normalized values.
  *
- * @param {Object} options An object of options to configure the request
+ * @param {Object} options An object of options to configure the request.
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
  */
@@ -48,10 +48,10 @@ ripe.Ripe.prototype.getPriceRulesP = function(options) {
 };
 
 /**
- * Gets an existing price rule filtered by id and according to the
+ * Gets an existing price rule filtered by ID and according to the
  * provided filtering strategy as normalized values.
  *
- * @param {Number} id The Price Rule's Id.
+ * @param {Number} id The price rule's ID.
  * @param {Object} options An object of options to configure the request
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
@@ -70,12 +70,12 @@ ripe.Ripe.prototype.getPriceRule = function(id, options, callback) {
 };
 
 /**
- * Gets an existing price rule filtered by id and according to the
+ * Gets an existing price rule filtered by ID and according to the
  * provided filtering strategy as normalized values.
  *
- * @param {Number} id The Price Rule's Id.
- * @param {Object} options An object of options to configure the request
- * @returns {Promise} The price rules list.
+ * @param {Number} id The price rule's ID.
+ * @param {Object} options An object of options to configure the request.
+ * @returns {Promise} The price rule requested by ID.
  */
 ripe.Ripe.prototype.getPriceRuleP = function(id, options) {
     return new Promise((resolve, reject) => {
@@ -86,10 +86,10 @@ ripe.Ripe.prototype.getPriceRuleP = function(id, options) {
 };
 
 /**
- * Creates a Price Rule on RIPE Core.
+ * Creates a price rule on RIPE Core.
  *
- * @param {Object} priceRule The Price Rule object
- * @param {Object} options An object with options
+ * @param {Object} priceRule An object with information needed to create a price rule.
+ * @param {Object} options An object with options.
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} Resulting information for the callback execution.
  */
@@ -108,10 +108,10 @@ ripe.Ripe.prototype.createPriceRule = function(priceRule, options, callback) {
 };
 
 /**
- * Creates a Price Rule on RIPE Core.
+ * Creates a price rule on RIPE Core.
  *
- * @param {Object} priceRule The Price Rule object
- * @param {Object} options An object with options
+ * @param {Object} priceRule An object with information needed to create a price rule.
+ * @param {Object} options An object with options.
  * @returns {Promise} The price rule's data.
  */
 ripe.Ripe.prototype.createPriceRuleP = function(priceRule, options) {
@@ -123,9 +123,9 @@ ripe.Ripe.prototype.createPriceRuleP = function(priceRule, options) {
 };
 
 /**
- * Updates a Price Rule on RIPE Core.
+ * Updates a price rule on RIPE Core.
  *
- * @param {Object} priceRule The Price Rule object
+ * @param {Object} priceRule An object with information needed to update a price rule.
  * @param {Object} options An object of options to configure the request
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} Resulting information for the callback execution.
@@ -145,11 +145,11 @@ ripe.Ripe.prototype.updatePriceRule = function(priceRule, options, callback) {
 };
 
 /**
- * Updates a Price Rule on RIPE Core.
+ * Updates a price rule on RIPE Core.
  *
- * @param {Object} priceRule The Price Rule object
- * @param {Object} options An object of options to configure the request
- * @returns {Promise} The Price Rule's data.
+ * @param {Object} priceRule An object with information needed to update a price rule.
+ * @param {Object} options An object of options to configure the request.
+ * @returns {Promise} The price rule's data.
  */
 ripe.Ripe.prototype.updatePriceRuleP = function(priceRule, options) {
     return new Promise((resolve, reject) => {
@@ -160,10 +160,9 @@ ripe.Ripe.prototype.updatePriceRuleP = function(priceRule, options) {
 };
 
 /**
- * Deletes the existing price rules filtered by id, according to the
- * provided filtering strategy as normalized values.
+ * Deletes an existing price rule.
  *
- * @param {Number} id The Price Rule's Id.
+ * @param {Number} id The price rule's ID.
  * @param {Object} options An object of options to configure the request
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
@@ -182,12 +181,11 @@ ripe.Ripe.prototype.deletePriceRule = function(id, options, callback) {
 };
 
 /**
- * Deletes the existing price rules filtered by id, according to the
- * provided filtering strategy as normalized values.
+ * Deletes an existing price rule.
  *
- * @param {Number} id The Price Rule's Id.
+ * @param {Number} id The price rule's ID.
  * @param {Object} options An object of options to configure the request
- * @returns {Promise} The price rules list.
+ * @returns {Promise} The result of the price rule's deletion.
  */
 ripe.Ripe.prototype.deletePriceRuleP = function(id, options) {
     return new Promise((resolve, reject) => {

--- a/src/js/base/logic.js
+++ b/src/js/base/logic.js
@@ -26,7 +26,7 @@ if (
  * @param {Object} bundle The locale strings bundle that is going to be
  * globally registered.
  * @param {String} locale The ISO 639-1 based locale identifier in the
- * underscore based form to be used in registration
+ * underscore based form to be used in registration.
  */
 ripe.Ripe.prototype.addBundle = function(bundle, locale = null) {
     locale = locale === null ? this.locale : locale;
@@ -44,7 +44,7 @@ ripe.Ripe.prototype.addBundle = function(bundle, locale = null) {
  * @param {Object} bundle The locale strings bundle that is going to be
  * globally removed.
  * @param {String} locale The ISO 639-1 based locale identifier in the
- * underscore based form to be used in removal
+ * underscore based form to be used in removal.
  */
 ripe.Ripe.prototype.removeBundle = function(bundle, locale = null) {
     locale = locale === null ? this.locale : locale;

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -701,7 +701,7 @@ ripe.Ripe.prototype.setOptions = function(options = {}) {
  * @param {String} material The material to change to.
  * @param {String} color The color to change to.
  * @param {Boolean} events If the parts events should be triggered (defaults to 'true').
- * @param {Object} options The options to be used in the set part operations (for internal use)..
+ * @param {Object} options The options to be used in the set part operations (for internal use).
  */
 ripe.Ripe.prototype.setPart = async function(part, material, color, events = true, options = {}) {
     const runUpdate = options.runUpdate === undefined ? true : options.runUpdate;
@@ -1783,7 +1783,7 @@ ripe.Ripe.prototype._handleCtx = function(result) {
  * @param {Object} loadedConfig The configuration structure that
  * has just been loaded.
  * @returns {Object} The state object that can be used to control
- * the state of parts, materials and colors;
+ * the state of parts, materials and colors.
  */
 ripe.Ripe.prototype._toChoices = function(loadedConfig) {
     const choices = {};


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | While doing methods for the new SKU endpoints, I noticed several inconsistencies in the documentation. Missing periods, `id` in lowercase, capitalized entities and duplicated lines. |
| Animated GIF | -- |
