### PR TITLE
fix: configurator cancel signature error

### DIFF
--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -286,7 +286,7 @@ ripe.ConfiguratorPrc.prototype.update = async function(state, options = {}) {
  * @param {Object} options Set of optional parameters to adjust the Configurator.
  */
 ripe.ConfiguratorPrc.prototype.cancel = async function(options = {}) {
-    if (this._buildSignature() === this.signature || "") return false;
+    if (this._buildSignature() !== (this.signature || "")) return false;
     if (this._finalize) this._finalize({ canceled: true });
     return true;
 };
@@ -1310,6 +1310,7 @@ ripe.ConfiguratorPrc.prototype._preload = async function(useChain) {
 
             // finalizes the promise by resolving it with
             // the parameter that was just received (final result)
+            console.log("configurator _finalize");
             resolve(result);
         };
 
@@ -1340,6 +1341,10 @@ ripe.ConfiguratorPrc.prototype._preload = async function(useChain) {
         };
 
         const render = async () => {
+            if (!this.owner) {
+                if (this._finalize) this._finalize();
+                return;
+            }
             const _index = this.index;
             if (index !== _index) {
                 return;
@@ -1361,6 +1366,7 @@ ripe.ConfiguratorPrc.prototype._preload = async function(useChain) {
 
             // determines if a chain based loading should be used for the
             // pre-loading process of the continuous image resources to be loaded
+            console.log("configurator render");
             const _frame = ripe.parseFrameKey(frame);
             const view = _frame[0];
             const position = _frame[1];

--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -1341,10 +1341,6 @@ ripe.ConfiguratorPrc.prototype._preload = async function(useChain) {
         };
 
         const render = async () => {
-            if (!this.owner) {
-                if (this._finalize) this._finalize();
-                return;
-            }
             const _index = this.index;
             if (index !== _index) {
                 return;
@@ -1366,7 +1362,6 @@ ripe.ConfiguratorPrc.prototype._preload = async function(useChain) {
 
             // determines if a chain based loading should be used for the
             // pre-loading process of the continuous image resources to be loaded
-            console.log("configurator render");
             const _frame = ripe.parseFrameKey(frame);
             const view = _frame[0];
             const position = _frame[1];

--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -220,7 +220,6 @@ ripe.ConfiguratorPrc.prototype.update = async function(state, options = {}) {
     const signature = this._buildSignature();
     const changed = signature !== previous;
     const animate = options.animate === undefined ? (changed ? "simple" : false) : options.animate;
-    this.signature = signature;
 
     // if the parts and the position haven't changed
     // since the last frame load then ignores the
@@ -274,6 +273,8 @@ ripe.ConfiguratorPrc.prototype.update = async function(state, options = {}) {
         this.trigger("loaded");
     }
 
+    this.signature = signature;
+
     // returns the resulting value indicating if the loading operation
     // as been triggered with success (effective operation)
     return result;
@@ -286,7 +287,7 @@ ripe.ConfiguratorPrc.prototype.update = async function(state, options = {}) {
  * @param {Object} options Set of optional parameters to adjust the Configurator.
  */
 ripe.ConfiguratorPrc.prototype.cancel = async function(options = {}) {
-    if (this._buildSignature() !== (this.signature || "")) return false;
+    if (this._buildSignature() === this.signature || "") return false;
     if (this._finalize) this._finalize({ canceled: true });
     return true;
 };

--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -1310,7 +1310,6 @@ ripe.ConfiguratorPrc.prototype._preload = async function(useChain) {
 
             // finalizes the promise by resolving it with
             // the parameter that was just received (final result)
-            console.log("configurator _finalize");
             resolve(result);
         };
 

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -246,6 +246,8 @@ ripe.Image.prototype.updateOptions = async function(options, update = true) {
  *
  * @param {Object} state An object containing the new state of the owner.
  * @param {Object} options Set of optional parameters to adjust the Image.
+ * @returns {Boolean} If an effective operation has been performed by the
+ * update operation.
  */
 ripe.Image.prototype.update = async function(state, options = {}) {
     // in case the element is no longer available (possible due to async
@@ -447,6 +449,8 @@ ripe.Image.prototype.update = async function(state, options = {}) {
  * in the child should be canceled this way an Image is not updated.
  *
  * @param {Object} options Set of optional parameters to adjust the Image.
+ * @returns {Boolean} If an effective operation has been performed or if
+ * instead no cancel logic was executed.
  */
 ripe.Image.prototype.cancel = async function(options = {}) {
     // in case the image is not under a loading process then


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Originated from https://github.com/ripe-tech/ripe-twitch-ui/pull/54 (read description) |
| Dependencies | -- |
| Decisions | From what I understood, the configuration cancel operation proceeds if the signatures don't match, since this means that there is an update process happening. However, the signature assignment was happening earlier in the update process and, when trying to cancel it would not work, since the signatures would match, even with the `_loadFrame` and preload happening. <br><br>By moving the signature assignment below, the signatures will only match when all promises are finished, and the cancel operation will successfully be performed when the `_preload` action is in the process (by running the `_finalize`).<br><br> The reasoning behind this came from a problem where the configurator was canceled in the middle of an update. This caused the SDK to get stuck when updating its children in the code below https://github.com/ripe-tech/ripe-sdk/blob/767dfd77d3635b45e611462bfb95950d96bc205b/src/js/base/ripe.js#L1294 It seems the update gets stuck on the `preloadPromise` of the configurator, which was not canceled by `cancel` called before https://github.com/ripe-tech/ripe-sdk/blob/767dfd77d3635b45e611462bfb95950d96bc205b/src/js/visual/configurator-prc.js#L269 The configuration cancelation never passed by the `_finalize` step, canceling all the render operations, even when it was defined. <br><br> With this fix, after several tries on my part by spamming the "customization" part of the twitch journey, I couldn't not reproduce the error. @3rdvision also tested and only reproduced it with "ridiculous" spamming. In the last gifs there are examples of this spamming, and it works. I don't know if this fixes the problem. |
| Animated GIF | Problem: <br> ![change_stuff_bug](https://user-images.githubusercontent.com/25725586/106014995-f4f55d00-60b5-11eb-9b7f-d9e3c0da4765.gif)<br> Now: <br>![fix-sdk-journey](https://user-images.githubusercontent.com/25725586/106015053-ffaff200-60b5-11eb-8e94-0ba747738c8c.gif)<br>![spam-sdk-fixed](https://user-images.githubusercontent.com/25725586/106164413-d8265b80-6181-11eb-8079-01e8a6eb939c.gif) ![spam-sdk-bug](https://user-images.githubusercontent.com/25725586/106165991-9d252780-6183-11eb-86b6-a759e5d3bd01.gif)|
