### PR TITLE
feat: support string in _parseExtraS

### DIFF
--- a/src/js/base/api.js
+++ b/src/js/base/api.js
@@ -1198,6 +1198,7 @@ ripe.Ripe.prototype._partsMToTriplets = function(partsM, sort = true) {
 
 ripe.Ripe.prototype._parseExtraS = function(extraS) {
     const extra = {};
+    if (!Array.isArray(extraS)) extraS = [extraS];
     for (const extraI of extraS) {
         const [name, initials, engraving] = ripe.splitUnescape(extraI, ":", 2);
         extra[name] = {

--- a/test/js/base/api.js
+++ b/test/js/base/api.js
@@ -63,6 +63,27 @@ describe("RipeAPI", function() {
                 initials_extra: {}
             });
         });
+
+        it("should be able to convert a query to spec with initials extra with one group", async () => {
+            const remote = ripe.RipeAPI();
+
+            const spec = remote._queryToSpec(
+                "brand=dummy&model=dummy&p=piping:leather_dmy:black&initials_extra=main:AA:black:style"
+            );
+            assert.deepStrictEqual(spec, {
+                brand: "dummy",
+                model: "dummy",
+                parts: {
+                    piping: {
+                        material: "leather_dmy",
+                        color: "black"
+                    }
+                },
+                initials: null,
+                engraving: null,
+                initials_extra: { main: { initials: "AA", engraving: "black:style" } }
+            });
+        });
     });
 
     describe("#_buildQuery()", function() {
@@ -241,7 +262,7 @@ describe("RipeAPI", function() {
     });
 
     describe("#_parseExtraS()", function() {
-        it("should properly parse an initials extra string", async () => {
+        it("should properly parse an initials extra string array", async () => {
             let result = null;
 
             const remote = ripe.RipeAPI();
@@ -267,6 +288,29 @@ describe("RipeAPI", function() {
             assert.deepStrictEqual(result, {
                 left: { initials: "pt:tp", engraving: null },
                 right: { initials: "tp:pt", engraving: null }
+            });
+        });
+
+        it("should properly parse an initials extra string", async () => {
+            let result = null;
+
+            const remote = ripe.RipeAPI();
+            result = remote._parseExtraS("main:pt:gold");
+
+            assert.deepStrictEqual(result, {
+                main: { initials: "pt", engraving: "gold" }
+            });
+
+            result = remote._parseExtraS("main:pt\\:tp:gold\\:yellow");
+
+            assert.deepStrictEqual(result, {
+                main: { initials: "pt:tp", engraving: "gold:yellow" }
+            });
+
+            result = remote._parseExtraS("left:pt\\:tp:");
+
+            assert.deepStrictEqual(result, {
+                left: { initials: "pt:tp", engraving: null }
             });
         });
     });


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Originated from https://github.com/ripe-tech/ripe-twitch-ui/pull/71 |
| Dependencies | -- |
| Decisions | The twitch ui uses only initialsExtra to save the initials state. This caused problems when using an URL with only one group in the initials extra field. <br> The `_parseExtraS` function does not support extraS to be a string. However this can happen if the `initials_extra` in the URL comes with only one group, and the `_unpackQuery` function returns the initials_extra as string instead of an array. <br> This caused errors in the parsing, where instead of returning a correct `initialsExtra` object, it returned an object parsed by each letter. <br><br> Tests for `_parseExtraS` and `_queryToSpec` added. |
| Animated GIF | **Without fix**: <br> ![image](https://user-images.githubusercontent.com/25725586/106466273-07471080-6493-11eb-8293-b7f108b10893.png) <br> **With fix**: <br> ![image](https://user-images.githubusercontent.com/25725586/106466356-20e85800-6493-11eb-8444-fb924d951dca.png) |
