### PR TITLE
fix: support initialsExtra with one group in _queryToSpec

### DIFF
--- a/src/js/base/api.js
+++ b/src/js/base/api.js
@@ -1102,6 +1102,7 @@ ripe.Ripe.prototype._queryToSpec = function(query) {
     const engraving = options.engraving || null;
     let initialsExtra = options.initials_extra || [];
     let tuples = options.p || [];
+    initialsExtra = Array.isArray(initialsExtra) ? initialsExtra : [initialsExtra];
     initialsExtra = this._parseExtraS(initialsExtra);
     tuples = Array.isArray(tuples) ? tuples : [tuples];
     const parts = this._tuplesToParts(tuples);

--- a/test/js/base/api.js
+++ b/test/js/base/api.js
@@ -63,6 +63,27 @@ describe("RipeAPI", function() {
                 initials_extra: {}
             });
         });
+
+        it("should be able to convert a query to spec with initials extra with one group", async () => {
+            const remote = ripe.RipeAPI();
+
+            const spec = remote._queryToSpec(
+                "brand=dummy&model=dummy&p=piping:leather_dmy:black&initials_extra=main:AA:black:style"
+            );
+            assert.deepStrictEqual(spec, {
+                brand: "dummy",
+                model: "dummy",
+                parts: {
+                    piping: {
+                        material: "leather_dmy",
+                        color: "black"
+                    }
+                },
+                initials: null,
+                engraving: null,
+                initials_extra: { main: { initials: "AA", engraving: "black:style" } }
+            });
+        });
     });
 
     describe("#_buildQuery()", function() {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Originated from https://github.com/ripe-tech/ripe-twitch-ui/pull/71 |
| Dependencies | -- |
| Decisions | The twitch ui uses only initialsExtra to save the initials state. This caused problems when using an URL with only one group in the initials extra field. <br> The `_parseExtraS` function does not support extraS to be a string. However this can happen if the `initials_extra` in the URL comes with only one group, and the `_unpackQuery` function returns the initials_extra as string instead of an array. <br> This caused errors in the parsing, where instead of returning a correct `initialsExtra` object, it returned an object parsed by each letter. <br><br> Based on the previous PR (https://github.com/ripe-tech/ripe-sdk/pull/237#issuecomment-770874298), the solution was moved to `_queryToSpec`, similar to the tuples approach. |
| Animated GIF |![image](https://user-images.githubusercontent.com/25725586/106469400-221b8400-6497-11eb-8e2d-29c9cc054ea1.png)|
