### PR TITLE
#36: Export and add types to `getPriceP`

### DIFF
--- a/types/api/order.d.ts
+++ b/types/api/order.d.ts
@@ -42,10 +42,7 @@ export type Order = {
     tracking_url?: string;
     report_url_e?: string;
     notes?: string[];
-    prices?: {
-        components: Record<string, ComponentPrice>;
-        total: TotalPrice;
-    };
+    prices?: Prices;
     states?: OrderState[];
     attachments?: Attachment[];
     account?: string;
@@ -115,6 +112,11 @@ export type OrderDetails = {
     url: string;
     image: string;
     extras: number;
+};
+
+export type Prices = {
+    components: Record<string, ComponentPrice>;
+    total: TotalPrice;
 };
 
 export type ComponentPrice = {

--- a/types/base/api.d.ts
+++ b/types/base/api.d.ts
@@ -1,4 +1,4 @@
-import { Order } from "../api";
+import { Order, Prices } from "../api";
 
 export type Part = {
     name: string;
@@ -46,6 +46,22 @@ export type ImportOrderOptions = {
     meta?: string[];
 };
 
+export type PriceOptions = {
+    brand?: string;
+    model?: string;
+    variant?: string;
+    version?: string;
+    frame?: string;
+    parts?: Part[];
+    engraving?: string;
+    initials?: string;
+    initialsExtra?: InitialsExtra;
+    country?: string;
+    currency?: string;
+    flag?: boolean;
+    full?: boolean;
+};
+
 export type RequestOptions = {
     url?: string;
     method?: string;
@@ -71,5 +87,6 @@ export declare class RipeAPI {
     importOrderP(ffOrderId: string, options?: ImportOrderOptions): Promise<Order>;
     getOrdersP(options?: GetRequestOptions): Promise<Order[]>;
     deleteOrderP(number: number, options?: RequestOptions): Promise<void>;
+    getPriceP(options?: PriceOptions): Promise<Prices>;
     _queryToSpec(query: string): Spec;
 }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-twitch/issues/36 |
| Dependencies |--|
| Decisions | Add types and export `getPriceP` |

