### PR TITLE
fix: FileTuple prototype fix

### DIFF
--- a/src/js/base/struct.js
+++ b/src/js/base/struct.js
@@ -15,7 +15,7 @@ ripe.FileTuple = function(...args) {
     this.push(...args);
 };
 
-ripe.FileTuple.prototype = Array.prototype;
+ripe.FileTuple.prototype = Object.create(Array.prototype);
 ripe.FileTuple.prototype.constructor = ripe.FileTuple;
 
 ripe.FileTuple.fromData = function(data, name = null, mime = null) {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Related to `juice` problem in PR https://github.com/ripe-tech/epir-papyrus/pull/86 |
| Dependencies | -- |
| Decisions | `FileTuple` prototype assignment was also changing the `Array` prototype https://github.com/ripe-tech/ripe-sdk/blob/3096ffb0c7b9ce341f772e8fab974f3bad64ea12/src/js/base/struct.js#L18 which is used by `cheerio`, a `juice` dependency. This was causing weird behaviour in `juice`, resulting in a fatal error. <br> The solution was using Javascript's [`Object.create`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create). |
| Animated GIF | **Before fix** `Array.prototype` before and after FileTuple prototype assigment: <br>![image](https://user-images.githubusercontent.com/25725586/107509717-d5bcfc00-6b9a-11eb-92c3-b29820529262.png)<br>**After fix** `Array.prototype` before and after FileTuple prototype assigment: <br>![image](https://user-images.githubusercontent.com/25725586/107509795-f2593400-6b9a-11eb-94fd-7f3cd33a4334.png)|
