### PR TITLE
test: verify that the array constructor is not overriden by FileTuple

### DIFF
--- a/test/js/base/struct.js
+++ b/test/js/base/struct.js
@@ -11,6 +11,11 @@ describe("FileTuple", function() {
             assert.notStrictEqual(fileTuple, null);
             assert.strictEqual(fileTuple instanceof Array, true);
         });
+
+        it("should not override the array class", () => {
+            assert.notStrictEqual(ripe.ripe.FileTuple.prototype.constructor, Array);
+            assert.strictEqual(Array.prototype.constructor, Array);
+        });
     });
 
     describe("#fromData()", async function() {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-sdk/pull/241#issuecomment-776772209 |
| Dependencies | -- |
| Decisions | Unit test that checks that the Array constructor was not overridden by FileTuple. |
| Animated GIF | -- |
