### PR TITLE
fix: check if element is not defined in drawMask

### DIFF
--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -1199,6 +1199,10 @@ ripe.ConfiguratorPrc.prototype._loadMask = function(maskImage, view, position, o
  * @ignore
  */
 ripe.ConfiguratorPrc.prototype._drawMask = function(maskImage) {
+    // in case the element is no longer available (possible due to async
+    // nature of execution) returns the control flow immediately
+    if (!this.element) return;
+
     const mask = this.element.querySelector(".mask");
     const maskContext = mask.getContext("2d");
     maskContext.clearRect(0, 0, mask.width, mask.height);


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Related to https://github.com/ripe-tech/ripe-twitch-ui/pull/88 |
| Dependencies | -- |
| Decisions | When destroying rapidly the configurator, the `_drawMask` function can still be called if caught between the 150 timeout in https://github.com/ripe-tech/ripe-sdk/blob/4a237e48530b57efd9171cdffd6ad7492f2b6be4/src/js/visual/configurator-prc.js#L1178-L1188 <br> This resulted in a console error, but otherwise did not impact the functioning of anything. <br> The fix is similar to the ones applied in other places. |
| Animated GIF | -- |
