### PR TITLE
#650: Save and later execute changeFrame operations while preloading

### DIFF
--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -1372,6 +1372,7 @@ ripe.ConfiguratorPrc.prototype._preload = async function(useChain) {
             const _index = this.index;
             if (index !== _index) return;
             if (!this.element) return;
+
             // removes the preloading class from the image element
             // this is considered the default operation
             else element.classList.remove("preloading");

--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -328,14 +328,13 @@ ripe.ConfiguratorPrc.prototype.cancel = async function(options = {}) {
  */
 ripe.ConfiguratorPrc.prototype.flushPending = async function() {
     while (this.pendingOperations.length > 0) {
-        const operation = this.pendingOperations.shift();
-        const [name, ...args] = operation;
-        switch (name) {
+        const { operation, args } = this.pendingOperations.shift();
+        switch (operation) {
             case "changeFrame":
                 await this.changeFrame(...args);
                 break;
             default:
-                break;
+                throw new Error(`Operation ${operation} is not valid`);
         }
     }
 };
@@ -455,10 +454,10 @@ ripe.ConfiguratorPrc.prototype.changeFrame = async function(frame, options = {})
     }
 
     // in case the safe mode is enabled and the current configuration is
-    // still under the preloading situation the change frame is saved in
-    // and will be executed after the preloading
+    // still under the preloading situation the change frame is saved and
+    // will be executed after the preloading
     if (safe && this.element.classList.contains("preloading")) {
-        this.pendingOperations = [["changeFrame", frame, options]];
+        this.pendingOperations = [{ operation: "changeFrame", args: [frame, options] }];
         return;
     }
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/650 |
| Dependencies | |
| Decisions | **Problem:** When customizing and then clicking in another part, the `changeFrame` call was being executed when the `configurator` was still `preloading`, resulting in the change frame operation being ignored an never executed: https://github.com/ripe-tech/ripe-sdk/blob/dd48403c58cf4f30d091f28cdc9425fd66de7b9a/src/js/visual/configurator-prc.js#L432-L434 <br>**Solution**: Save the operation in an array of pending operations to be executed later when the preloading promise ends. This needs to also happen when the preload is cancelled, since it would result in lost alterations when doing several customizations. |
| Animated GIF | ![preferred-frame-fix](https://user-images.githubusercontent.com/25725586/108093324-7f0d6180-7075-11eb-8c98-beeb17fdb6fe.gif)|
