### PR TITLE
#641 Fix setting initialsExtra in root and options of ripe instance

### DIFF
--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -779,10 +779,18 @@ ripe.Ripe.prototype.setParts = async function(update, events = true, options = {
  * @param {String} engraving The type of engraving to be set.
  * @param {Boolean} events If the events associated with the initials
  * change should be triggered.
+ * @param {Boolean} override If the options value should be override meaning
+ * that further config updates will have this new initials set.
  * @param {Object} params Extra parameters that control the behaviour of
  * the set initials operation.
  */
-ripe.Ripe.prototype.setInitials = async function(initials, engraving, events = true, params = {}) {
+ripe.Ripe.prototype.setInitials = async function(
+    initials,
+    engraving,
+    events = true,
+    override = false,
+    params = {}
+) {
     if (typeof initials === "object") {
         events = engraving === undefined ? true : engraving;
         const result = await this.setInitialsExtra(initials, events);
@@ -814,6 +822,14 @@ ripe.Ripe.prototype.setInitials = async function(initials, engraving, events = t
 
     if (!this.initials && this.engraving) {
         throw new Error("Engraving set without initials");
+    }
+
+    // in case the override flag is set then the options fields
+    // are also update with the new initials values
+    if (override) {
+        this.options.initials = this.initials;
+        this.options.engraving = this.engraving;
+        this.options.initialsExtra = this.initialsExtra;
     }
 
     // in case the events should not be triggered then returns
@@ -853,10 +869,17 @@ ripe.Ripe.prototype.setInitials = async function(initials, engraving, events = t
  * initials and engraving for all the initial groups.
  * @param {Boolean} events If the events associated with the changing of
  * the initials (extra) should be triggered.
+ * @param {Boolean} override If the options value should be override meaning
+ * that further config updates will have this new initials extra set.
  * @param {Object} params Extra parameters that control the behaviour of
  * the set initials operation.
  */
-ripe.Ripe.prototype.setInitialsExtra = async function(initialsExtra, events = true, params = {}) {
+ripe.Ripe.prototype.setInitialsExtra = async function(
+    initialsExtra,
+    events = true,
+    override = false,
+    params = {}
+) {
     const groups = Object.keys(initialsExtra);
     const isEmpty = groups.length === 0;
     const mainGroup = groups.includes("main") ? "main" : groups[0];
@@ -880,16 +903,10 @@ ripe.Ripe.prototype.setInitialsExtra = async function(initialsExtra, events = tr
         this.initials = "";
         this.engraving = null;
         this.initialsExtra = {};
-        this.options.initials = "";
-        this.options.engraving = null;
-        this.options.initialsExtra = {};
     } else {
         this.initials = mainInitials.initials || "";
         this.engraving = mainInitials.engraving || null;
         this.initialsExtra = initialsExtra;
-        this.options.initials = mainInitials.initials || "";
-        this.options.engraving = mainInitials.engraving || null;
-        this.options.initialsExtra = initialsExtra;
     }
 
     for (const [key, value] of Object.entries(this.initialsExtra)) {
@@ -900,6 +917,14 @@ ripe.Ripe.prototype.setInitialsExtra = async function(initialsExtra, events = tr
         if (!value.initials && value.engraving) {
             throw new Error(`Engraving set without initials for group ${key}`);
         }
+    }
+
+    // in case the override flag is set then the options fields
+    // are also update with the new initials values
+    if (override) {
+        this.options.initials = this.initials;
+        this.options.engraving = this.engraving;
+        this.options.initialsExtra = this.initialsExtra;
     }
 
     if (!events) return this;

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -878,10 +878,16 @@ ripe.Ripe.prototype.setInitialsExtra = async function(initialsExtra, events = tr
         this.initials = "";
         this.engraving = null;
         this.initialsExtra = {};
+        this.options.initials = "";
+        this.options.engraving = null;
+        this.options.initialsExtra = {};
     } else {
         this.initials = mainInitials.initials || "";
         this.engraving = mainInitials.engraving || null;
         this.initialsExtra = initialsExtra;
+        this.options.initials = mainInitials.initials || "";
+        this.options.engraving = mainInitials.engraving || null;
+        this.options.initialsExtra = initialsExtra;
     }
 
     for (const [key, value] of Object.entries(this.initialsExtra)) {

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -1800,7 +1800,7 @@ ripe.Ripe.prototype._handleCtx = function(result) {
     this.parts = Object.assign(this.parts, result.parts);
 
     if (result.initials && !ripe.equal(result.initials, this.initialsExtra)) {
-        this.setInitialsExtra(result.initials, true, { noRemote: true });
+        this.setInitialsExtra(result.initials, true, false, { noRemote: true });
     }
 
     if (result.choices && !ripe.equal(result.choices, this.choices)) {

--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -1378,7 +1378,6 @@ ripe.ConfiguratorPrc.prototype._preload = async function(useChain) {
             const _index = this.index;
             if (index !== _index) return;
             if (!this.element) return;
-
             // removes the preloading class from the image element
             // this is considered the default operation
             else element.classList.remove("preloading");


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/641#issuecomment-780589887 |
| Decisions | This bug was introduced at a [refactor](https://github.com/ripe-tech/ripe-white/commit/53473e502528c44efd547b90bf039c7a06267db3#diff-b671d69de830c33eb2f46a7ef178954ff04079bb2baaa93fa568759b45781accR132) after the [fix](https://github.com/ripe-tech/ripe-white/pull/643). This regression exposes an unexpected RIPE SDK behavior - when we do `setInitialsExtra` it sets `ripe.initialsExtra` but not `ripe.options.initialsExtra`. <br><br>On the other hand `config()` sets both `ripe.initialsExtra` and `ripe.options.initialsExtra`, that's why it was working before the refactor when we were doing everything in `config()`.<br><br>Now RIPE White uses `$ripe.initials`, `$ripe.engraving` and `$ripe.initialsExtra` for the `originalState` and `$ripe.options.initials`, `$ripe.options.engraving` and `$ripe.options.initialsExtra` for the `state`. When we reproduce the bug by changing to a different model it will reset the `originalState` correctly but not the `state` (`ripe.options.initialsExtra` is still dirty with old model's personalization). This buttonText showing the old personalization happens only for a short amount of time depending on how fast the JS code runs because it later receives an event with empty personalization which overrides it but the old state always remains there.<br><br> This fix sets both `ripe.initialsExtra` and `ripe.options.initialsExtra` when doing `setInitialsExtra` <br><br> **Note:** [setSize](https://github.com/ripe-tech/ripe-sdk/blob/master/src/js/base/ripe.js#L1075) already writes to both `this.size` and `this.options.size` so we might want the same effect for `setInitials` and `setInitialsExtra`. |
| Animated GIF | ![Peek 2021-02-18 17-09](https://user-images.githubusercontent.com/24736423/108394096-418f0c80-720c-11eb-94b2-449640df28dd.gif) |
