### PR TITLE
Pass version along request

### DIFF
--- a/src/js/api/build.js
+++ b/src/js/api/build.js
@@ -293,11 +293,11 @@ ripe.Ripe.prototype.switchBuildP = function(name, options) {
  * @param {Object} options An object of options to configure the request.
  * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
  */
-ripe.Ripe.prototype.getBuildArtifacts = function(name, options, callback) {
+ripe.Ripe.prototype.getBuildArtifacts = function(name, version, options, callback) {
     callback = typeof options === "function" ? options : callback;
     options = typeof options === "function" || options === undefined ? {} : options;
     const branch = options.branch === undefined ? "master" : options.branch;
-    const url = `${this.url}builds/${name}/artifacts`;
+    const url = `${this.url}builds/${name}/artifacts${version ? `/${version}` : ""}`;
     const params = {};
     if (branch !== undefined && branch !== null) {
         params.branch = branch;
@@ -321,9 +321,9 @@ ripe.Ripe.prototype.getBuildArtifacts = function(name, options, callback) {
  * @param {Object} options An object of options to configure the request.
  * @returns {Promise} The build artifacts (as a promise).
  */
-ripe.Ripe.prototype.getBuildArtifactsP = function(name, options) {
+ripe.Ripe.prototype.getBuildArtifactsP = function(name, version, options) {
     return new Promise((resolve, reject) => {
-        this.getBuildArtifacts(name, options, (result, isValid, request) => {
+        this.getBuildArtifacts(name, version, options, (result, isValid, request) => {
             isValid ? resolve(result) : reject(new ripe.RemoteError(request, null, result));
         });
     });


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-twitch/issues/89 |
| Dependencies | -- |
| Decisions | The Twitch issue won't likely use it and just returns the latest version. However, based on the docstrings, it appears that the version should be passed along the several SDK functions. If the version is defined, the request should be `builds/:name/artifacts/:version` and `builds/:name/artifacts` otherwise|

