### PR TITLE
#845 Fix missing variant in _getState

### DIFF
--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -1628,7 +1628,8 @@ ripe.Ripe.prototype._getState = function(safe = true) {
               parts: this.parts,
               initials: this.initials,
               engraving: this.engraving,
-              initialsExtra: this.initialsExtra
+              initialsExtra: this.initialsExtra,
+              variant: this.variant
           };
 };
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/825 |
| Decisions | Add missing `variant` to `_getState` return object so variant isn't ignored when doing [_update](https://github.com/ripe-tech/ripe-sdk/blob/master/src/js/base/ripe.js#L1287) as it is clearly needed later on when [getPriceP](https://github.com/ripe-tech/ripe-sdk/blob/master/src/js/base/ripe.js#L1314) is called. This is a dependency for a [higher level fix in ripe-commons-pluginus](https://github.com/ripe-tech/ripe-commons-pluginus/pull/237).   |
