### PR TITLE
Calling config(), setParts() and setPart() now cascades options to configurators

### DIFF
--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -722,7 +722,8 @@ ripe.Ripe.prototype.setPart = async function(part, material, color, events = tru
 
     // propagates the state change in the internal structures to the
     // children elements of this Ripe Instance
-    const promise = this.update(undefined, { reason: "set part" });
+    const fullOptions = { ...options, ...{ reason: "set part", noAwaitLayout: true } };
+    const promise = this.update(undefined, fullOptions);
 
     // in case the wait update options is valid (by default) then waits
     // until the update promise is fulfilled
@@ -761,7 +762,8 @@ ripe.Ripe.prototype.setParts = async function(update, events = true, options = {
 
     // propagates the state change in the internal structures to the
     // children elements of this Ripe Instance
-    const promise = this.update(undefined, { reason: "set parts" });
+    const fullOptions = { ...options, ...{ reason: "set parts", noAwaitLayout: true } };
+    const promise = this.update(undefined, fullOptions);
 
     // in case the wait update options is valid (by default) then waits
     // until the update promise is fulfilled

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -516,10 +516,8 @@ ripe.Ripe.prototype.config = async function(brand, model, options = {}) {
 
     // runs the initial update operation, so that all the visuals and children
     // objects are properly updated according to the new configuration
-    const updatePromise = this.update(undefined, {
-        noAwaitLayout: true,
-        reason: "config"
-    });
+    const fullOptions = { ...options, ...{ reason: "config", noAwaitLayout: true } };
+    const updatePromise = this.update(undefined, fullOptions);
     if (options.safe) await updatePromise;
 };
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | None |
| Dependencies | None |
| Decisions | Below |

When the specified functions are called, they call an `update`, with a specified reason. However, the options which were passed for the functions are not passed on in the update, so a configurator has no way of reading extra information, such as the duration of any event, for example. This caused problems [when attempting to use CSR as an alternative for PRC](https://github.com/ripe-tech/ripe-compose/issues/74) to create static images. 
When changing a configuration, a crossfade event is triggered, in which the CSR seamlessly transitions from one state to the next. For the use case of the issue, we needed the crossfade to be instantaneous, so as to generate a valid frame as soon as possible. Since the functions did not cascade the options, there was no way to explicitly tell the duration (despite the CSR being able to handle the parameter correctly). 

This PR enables this feature, so that we can explicitly call options with duration, which are passed onto the configurator to better deal with this specific issue. 
