### PR TITLE
feat: use node-fetch when global.fetch is not defined

### DIFF
--- a/src/js/base/compat.js
+++ b/src/js/base/compat.js
@@ -93,6 +93,8 @@ if (
         fetch = window.fetch;
     } else if (typeof global !== "undefined" && typeof global.fetch !== "undefined") {
         fetch = global.fetch;
+    } else if (typeof global !== "undefined") {
+        fetch = require("node-fetch").default;
     } else if (
         // eslint-disable-next-line camelcase
         typeof __webpack_require__ === "undefined" &&

--- a/src/js/base/compat.js
+++ b/src/js/base/compat.js
@@ -93,13 +93,15 @@ if (
         fetch = window.fetch;
     } else if (typeof global !== "undefined" && typeof global.fetch !== "undefined") {
         fetch = global.fetch;
-    } else if (typeof global !== "undefined") {
-        fetch = require("node-fetch").default;
     } else if (
         // eslint-disable-next-line camelcase
         typeof __webpack_require__ === "undefined" &&
         (typeof navigator === "undefined" || navigator.product !== "ReactNative")
     ) {
+        fetch = require("node-fetch").default;
+    } else if (typeof global !== "undefined" && typeof global.__VUE_SSR_CONTEXT__ !== "undefined") {
+        // this is a workaround for Nuxt.js SSR built as standalone,
+        // which does not have global.fetch populated
         fetch = require("node-fetch").default;
     }
 }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | In `epir-papryus` an error occurred when running the deployed version, when the SDK initialization was made. This was due to the fact that `fetch` was not defined: <br>![image](https://user-images.githubusercontent.com/25725586/117636788-0e0fae80-b179-11eb-8c20-ac21067a3ff6.png) |
| Dependencies | -- |
| Decisions | Locally this works, but when running `nuxt --standalone`, the `global.fetch` is not defined. After some exploration, the variable `VUE_SSR_CONTEXT` is defined as an empty object in `global` when running nuxt as standalone. |
| Animated GIF | -- |
