### PR TITLE
feat: added noAwaitLayout to config options

### DIFF
--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -517,7 +517,7 @@ ripe.Ripe.prototype.config = async function(brand, model, options = {}) {
     // runs the initial update operation, so that all the visuals and children
     // objects are properly updated according to the new configuration
     const updatePromise = this.update(undefined, {
-        noAwaitLayout: true,
+        noAwaitLayout: options.noAwaitLayout === undefined ? true : options.noAwaitLayout,
         reason: "config"
     });
     if (options.safe) await updatePromise;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | Currently when calling the `config` function, the `noAwaitLayout` variable is hard-coded to true, which makes the function never wait for the updates of it's children. This causes a problem for ripe-compose-csr, in which we use `config` to change the parts for the model, but even with `await`, calling the function did not correctly wait for the update to be processed and rendered. With this small change, we can now call the `config`, knowing that the update finished completely when the function returned.  |
