### PR TITLE
#84: fix initials builder calls

### DIFF
--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -1917,8 +1917,8 @@ ripe.Ripe.prototype._initialsBuilder = function(
     viewport = null,
     context = null
 ) {
-    let profiles = this._generateProfiles(group, viewport);
-    profiles = this._buildProfiles(engraving, profiles, context);
+    let profiles = this.owner._generateProfiles(group, viewport);
+    profiles = this.owner._buildProfiles(engraving, profiles, context);
     return {
         initials: initials,
         profile: profiles

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -97,7 +97,7 @@ ripe.Ripe.prototype.init = async function(brand = null, model = null, options = 
     this.initials = "";
     this.engraving = null;
     this.initialsExtra = {};
-    this.initialsBuilder = null;
+    this.initialsBuilder = this._initialsBuilder;
     this.ctx = {};
     this.children = this.children || [];
     this.plugins = this.plugins || [];

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -1887,7 +1887,9 @@ ripe.Ripe.prototype._loadInitialsBuilder = async function() {
     });
     // eslint-disable-next-line no-eval
     const logicScript = eval(logicScriptText);
-    this.initialsBuilder = logicScript ? logicScript.initialsBuilder : this._initialsBuilder.bind(this);
+    this.initialsBuilder = logicScript
+        ? logicScript.initialsBuilder.bind(this)
+        : this._initialsBuilder.bind(this);
 };
 
 /**

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -97,7 +97,7 @@ ripe.Ripe.prototype.init = async function(brand = null, model = null, options = 
     this.initials = "";
     this.engraving = null;
     this.initialsExtra = {};
-    this.initialsBuilder = this._initialsBuilder;
+    this.initialsBuilder = this._initialsBuilder.bind(this);
     this.ctx = {};
     this.children = this.children || [];
     this.plugins = this.plugins || [];
@@ -1887,7 +1887,7 @@ ripe.Ripe.prototype._loadInitialsBuilder = async function() {
     });
     // eslint-disable-next-line no-eval
     const logicScript = eval(logicScriptText);
-    this.initialsBuilder = logicScript ? logicScript.initialsBuilder : this._initialsBuilder;
+    this.initialsBuilder = logicScript ? logicScript.initialsBuilder : this._initialsBuilder.bind(this);
 };
 
 /**
@@ -1917,8 +1917,8 @@ ripe.Ripe.prototype._initialsBuilder = function(
     viewport = null,
     context = null
 ) {
-    let profiles = this.owner._generateProfiles(group, viewport);
-    profiles = this.owner._buildProfiles(engraving, profiles, context);
+    let profiles = this._generateProfiles(group, viewport);
+    profiles = this._buildProfiles(engraving, profiles, context);
     return {
         initials: initials,
         profile: profiles


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-compose/issues/84 |
| Dependencies | -- |
| Decisions | Initializes `initialsBuilder` with the local implementation, so that if `useInitialsBuilderLogic` is false, it still has it defined. There was a problem that I did not notice (my mistake) with the calls made inside `initialsBuilder`, which needed to be inside the owner `context`. |
| Animated GIF | -- |
