### PR TITLE
Fix: Override tracking info and keep other params 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Mark order as sent propagates optional params
 
 ## [2.1.0] - 2021-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* Mark order as sent propagates optional params
+* Set order status takes relevant params from options and populates request params.
 
 ## [2.1.0] - 2021-06-22
 

--- a/src/js/api/order.js
+++ b/src/js/api/order.js
@@ -646,6 +646,7 @@ ripe.Ripe.prototype.sendOrder = function(number, trackingNumber, trackingUrl, op
     options = typeof options === "function" || options === undefined ? {} : options;
     options = Object.assign(options, {
         params: {
+            ...options.params,
             tracking_number: trackingNumber,
             tracking_url: trackingUrl
         }

--- a/src/js/api/order.js
+++ b/src/js/api/order.js
@@ -646,7 +646,6 @@ ripe.Ripe.prototype.sendOrder = function(number, trackingNumber, trackingUrl, op
     options = typeof options === "function" || options === undefined ? {} : options;
     options = Object.assign(options, {
         params: {
-            ...options.params,
             tracking_number: trackingNumber,
             tracking_url: trackingUrl
         }
@@ -997,6 +996,8 @@ ripe.Ripe.prototype.setOrderStatus = function(number, status, options, callback)
         auth: true,
         method: "PUT"
     });
+    options.params = options.params || {};
+    if (options.justification) options.params.justification = options.justification;
     options = this._build(options);
     return this._cacheURL(options.url, options, callback);
 };


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | Other option values passed (for example `justification`) were not being propagated as expected to `setOrderStatus`. |
