### PR TITLE
#219 Adds rejectOrder and rejectOrderP methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Ability to override `name` and `meta` for attachments - [#282](https://github.com/ripe-tech/ripe-sdk/issues/282)
-* Add `rejectOrderP` and `rejectOrder` methods
+* Add `rejectOrderP` and `rejectOrder` methods - [#219](https://github.com/ripe-tech/ripe-pulse/issues/219)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Add `rejectOrderP` and `rejectOrder` methods
 
 ### Changed
 

--- a/src/js/api/order.js
+++ b/src/js/api/order.js
@@ -622,6 +622,26 @@ ripe.Ripe.prototype.qualityAssureOrderP = function(number, options) {
 };
 
 /**
+ * Sets the order status to 'rejected'.
+ *
+ * @param {Number} number The number of the order to update.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
+ */
+ripe.Ripe.prototype.rejectOrder = function(number, options, callback) {
+    return this.setOrderStatus(number, "rejected", options, callback);
+};
+
+ripe.Ripe.prototype.rejectOrderP = function(number, options) {
+    return new Promise((resolve, reject) => {
+        this.rejectOrder(number, options, (result, isValid, request) => {
+            isValid ? resolve(result) : reject(new ripe.RemoteError(request, null, result));
+        });
+    });
+};
+
+/**
  * Sets the order status to 'ready'.
  *
  * @param {Number} number The number of the order to update.

--- a/src/js/api/order.js
+++ b/src/js/api/order.js
@@ -622,7 +622,7 @@ ripe.Ripe.prototype.qualityAssureOrderP = function(number, options) {
 };
 
 /**
- * Sets the order status to 'rejected'.
+ * Sets the order status to 'reject'.
  *
  * @param {Number} number The number of the order to update.
  * @param {Object} options An object of options to configure the request.
@@ -630,7 +630,7 @@ ripe.Ripe.prototype.qualityAssureOrderP = function(number, options) {
  * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
  */
 ripe.Ripe.prototype.rejectOrder = function(number, options, callback) {
-    return this.setOrderStatus(number, "rejected", options, callback);
+    return this.setOrderStatus(number, "reject", options, callback);
 };
 
 ripe.Ripe.prototype.rejectOrderP = function(number, options) {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-pulse/issues/219 |
| Dependencies | -- |
| Decisions | Add `rejectOrderP` and `rejectOrder` methods |

