### PR TITLE
fix: stateCreateAttachmentOrder regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Addition of attachments to a specific order state (`stateCreateAttachmentOrder`) - [#230](https://github.com/ripe-tech/ripe-pulse/issues/230)
 
 ## [2.2.0] - 2021-06-07
 

--- a/src/js/api/order.js
+++ b/src/js/api/order.js
@@ -484,9 +484,7 @@ ripe.Ripe.prototype.stateCreateAttachmentOrder = function(
     options = Object.assign(options, {
         url: url,
         method: "POST",
-        dataM: {
-            file: dataM
-        },
+        dataM: dataM,
         auth: true
     });
     options = this._build(options);


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-pulse/issues/230 |
