### PR TITLE
fix: support null context on buildProfiles function

### DIFF
--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -1989,6 +1989,10 @@ ripe.Ripe.prototype._buildProfiles = function(engraving, profiles, context, sep 
     const engravingProfiles = engraving ? this.parseEngraving(engraving).values : [];
     profiles = [...engravingProfiles, ...profiles];
 
+    // converts a possible null context into an empty array, supporting
+    // no context and only using the given profiles
+    context = context || [];
+
     // retrieves the ordered set of property types, which will be used to
     // order the profiles
     const propertyTypes = this.getProperties().propertyTypes;
@@ -2027,7 +2031,6 @@ ripe.Ripe.prototype._buildProfiles = function(engraving, profiles, context, sep 
         // iterates over the context values and construct all
         // the permutations with the existing combinations, both
         // normal and with their type and names reversed
-        if (!context) continue;
         for (const contextValue of context) {
             profile = [contextValue];
             profileWithName = [contextValue];

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -1982,7 +1982,7 @@ ripe.Ripe.prototype._generateProfiles = function(group, viewport) {
  * @returns {Array} The sequence of generated profiles properly ordered from the
  * most concrete (more specific) to the least concrete (more general).
  */
-ripe.Ripe.prototype._buildProfiles = function(engraving, profiles, context, sep = ":") {
+ripe.Ripe.prototype._buildProfiles = function(engraving, profiles, context = null, sep = ":") {
     // parses the provided engraving string so that it's possible to iterate
     // over the multiple structured values of it, then adds these same values
     // to the base values passed as argument to the method

--- a/test/js/base/ripe.js
+++ b/test/js/base/ripe.js
@@ -360,6 +360,17 @@ describe("Ripe", function() {
                 "white",
                 "step::size"
             ]);
+
+            result = instance._initialsBuilder("AA", "black:color.rib:position", null, null, null);
+            assert.strictEqual(result.initials, "AA");
+            assert.deepStrictEqual(result.profile, [
+                "color::black:position::rib",
+                "black:rib",
+                "position::rib",
+                "rib",
+                "color::black",
+                "black"
+            ]);
         });
     });
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Originated from @joao-conde ripe-green component which was setting no context. |
| Dependencies | |
| Decisions | If no context is provided (null), the profile building should still be made. This PR fixes that. |
| Animated GIF | -- |
