### PR TITLE
fix: sets default values for initials and engraving on image update

### DIFF
--- a/src/js/base/compat.js
+++ b/src/js/base/compat.js
@@ -99,7 +99,9 @@ if (
         typeof __webpack_require__ === "undefined" &&
         (typeof navigator === "undefined" || navigator.product !== "ReactNative")
     ) {
-        XMLHttpRequest = ripe.requireSafe("xmlhttprequest")?.XMLHttpRequest;
+        // eslint-disable-next-line no-var
+        var xmlhttprequest = ripe.requireSafe("xmlhttprequest");
+        XMLHttpRequest = xmlhttprequest ? xmlhttprequest.XMLHttpRequest : undefined;
     }
 }
 

--- a/src/js/base/compat.js
+++ b/src/js/base/compat.js
@@ -99,7 +99,7 @@ if (
         typeof __webpack_require__ === "undefined" &&
         (typeof navigator === "undefined" || navigator.product !== "ReactNative")
     ) {
-        XMLHttpRequest = ripe.requireSafe("xmlhttprequest").XMLHttpRequest;
+        XMLHttpRequest = ripe.requireSafe("xmlhttprequest")?.XMLHttpRequest;
     }
 }
 

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -313,6 +313,11 @@ ripe.Image.prototype.update = async function(state, options = {}) {
     const curve = this.element.dataset.curve || this.curve;
     const doubleBuffering = this.element.dataset.doubleBuffering || this.doubleBuffering;
 
+    // sets the default values of initials and engraving which may
+    // be overridden if a state was given
+    this.initials = "";
+    this.engraving = null;
+
     // in case the state is defined tries to gather the appropriate
     // sate options for both initials and engraving taking into
     // consideration that groups may exist

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -313,11 +313,6 @@ ripe.Image.prototype.update = async function(state, options = {}) {
     const curve = this.element.dataset.curve || this.curve;
     const doubleBuffering = this.element.dataset.doubleBuffering || this.doubleBuffering;
 
-    // sets the default values of initials and engraving which may
-    // be overridden if a state was given
-    this.initials = "";
-    this.engraving = null;
-
     // in case the state is defined tries to gather the appropriate
     // sate options for both initials and engraving taking into
     // consideration that groups may exist
@@ -438,6 +433,10 @@ ripe.Image.prototype.update = async function(state, options = {}) {
     let result = true;
 
     try {
+        // cancels the previous request (if exists), allowing the callbacks
+        // to be freed to make a new request
+        this.cancel();
+
         // create a promise waiting for the current image for either load
         // or receive an error, for both situation there should be a proper
         // waiting process in motion

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -406,6 +406,11 @@ ripe.Image.prototype.update = async function(state, options = {}) {
         return false;
     }
 
+    // cancels the previous request (if exists), firing the proper
+    // callbacks before overriding them in the current request, this
+    // will allow unblocking pending listeners for the previous images
+    await this.cancel();
+
     // saves the previous URL value and then updates the new URL
     // according to the newly requested one
     this._previousUrl = this._url;
@@ -420,11 +425,6 @@ ripe.Image.prototype.update = async function(state, options = {}) {
     // in case the element is no longer available (possible due to async
     // nature of execution) returns the control flow immediately
     if (!this.element) return;
-
-    // cancels the previous request (if exists), firing the proper
-    // callbacks before overriding them in the current request, this
-    // will allow unblocking pending listeners for the previous images
-    await this.cancel();
 
     // updates the image DOM element with the values of the image
     // including requested size and URL

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -433,8 +433,8 @@ ripe.Image.prototype.update = async function(state, options = {}) {
     let result = true;
 
     try {
-        // cancels the previous request (if exists), allowing the callbacks
-        // to be freed to make a new request
+        // cancels the previous request (if exists), firing the proper
+        // callbacks before overriding them in the current request
         this.cancel();
 
         // create a promise waiting for the current image for either load

--- a/test/js/visual.js
+++ b/test/js/visual.js
@@ -118,6 +118,23 @@ describe("Image", function() {
             );
         });
 
+        it("should generate the correct image URL with initials", async () => {
+            const dom = new jsdom.JSDOM("<img id='image' />", { resources: "usable" });
+            const imageElement = dom.window.document.getElementById("image");
+            const instance = new base.ripe.Ripe();
+            await instance.init("myswear", "vyner");
+            const image = instance.bindImage(imageElement, {
+                showInitials: true,
+                initialsContext: ["step::personalization"]
+            });
+            assert.strictEqual(image._url, null);
+            await image.update();
+            assert.strictEqual(
+                image._url,
+                "https://sandbox.platforme.com/api/compose?brand=myswear&initials=%24empty&initials_profile=step%3A%3Apersonalization&model=vyner&p=eyelets%3Ametal%3Asilver&p=front%3Anappa%3Awhite&p=laces%3Anylon%3Awhite&p=lining%3Acalf_lining%3Awhite&p=shadow%3Adefault%3Adefault&p=side%3Anappa%3Awhite&p=sole%3Arubber%3Awhite"
+            );
+        });
+
         it("should deinit image and stop updating", async () => {
             const dom = new jsdom.JSDOM("<img id='image' />", { resources: "usable" });
             const imageElement = dom.window.document.getElementById("image");

--- a/test/js/visual.js
+++ b/test/js/visual.js
@@ -128,10 +128,11 @@ describe("Image", function() {
                 initialsContext: ["step::personalization"]
             });
             assert.strictEqual(image._url, null);
-            await image.update();
+            await image.update({ initials: "A" });
+            await image.update({ initials: "B" });
             assert.strictEqual(
                 image._url,
-                "https://sandbox.platforme.com/api/compose?brand=myswear&initials=%24empty&initials_profile=step%3A%3Apersonalization&model=vyner&p=eyelets%3Ametal%3Asilver&p=front%3Anappa%3Awhite&p=laces%3Anylon%3Awhite&p=lining%3Acalf_lining%3Awhite&p=shadow%3Adefault%3Adefault&p=side%3Anappa%3Awhite&p=sole%3Arubber%3Awhite"
+                "https://sandbox.platforme.com/api/compose?brand=myswear&initials=B&initials_profile=step%3A%3Apersonalization&model=vyner&p=eyelets%3Ametal%3Asilver&p=front%3Anappa%3Awhite&p=laces%3Anylon%3Awhite&p=lining%3Acalf_lining%3Awhite&p=shadow%3Adefault%3Adefault&p=side%3Anappa%3Awhite&p=sole%3Arubber%3Awhite"
             );
         });
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | **What is happening?**<br>In the specific case of the test, without setting the default values, there are two different requests: the first has the URL without initials and sets the `_loadedCallback` to its callback when it loads. However, when the second requests comes, it has a different URL and overrides the loadedCallback, never allowing the first request to finish. <br>It's necessary to cancel the previous request before making a new one.|
| Animated GIF | Before:<br><img width="550" alt="image" src="https://user-images.githubusercontent.com/25725586/130098589-67ee338c-03e6-4ccf-a864-1ee7536150db.png"><br>Now:<br><img width="212" alt="image" src="https://user-images.githubusercontent.com/25725586/130098962-a34c2fd7-5056-4ae6-afb9-6809560aca9f.png">|
