### PR TITLE
fix: support combinations for initials builder of only 1 profile

### DIFF
--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -2015,10 +2015,14 @@ ripe.Ripe.prototype._buildProfiles = function(engraving, profiles, context = nul
     // and then iterates over the range of values size to create the
     // multiple combinations for the current values
     let combinations = [];
+    if (profiles.length === 1) {
+        combinations = [profiles];
+    } else {
     for (let i = 0; i < profiles.length; i++) {
         combinations = [...combinations, ...ripe.combinations(profiles, i + 1)];
     }
     combinations.reverse();
+    }
 
     // iterates over the profiles and append the context
     // to them, resulting in all the profile combinations

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -2018,10 +2018,10 @@ ripe.Ripe.prototype._buildProfiles = function(engraving, profiles, context = nul
     if (profiles.length === 1) {
         combinations = [profiles];
     } else {
-    for (let i = 0; i < profiles.length; i++) {
-        combinations = [...combinations, ...ripe.combinations(profiles, i + 1)];
-    }
-    combinations.reverse();
+        for (let i = 0; i < profiles.length; i++) {
+            combinations = [...combinations, ...ripe.combinations(profiles, i + 1)];
+        }
+        combinations.reverse();
     }
 
     // iterates over the profiles and append the context


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Found when implementing initials in ripe-green. |
| Dependencies | -- |
| Decisions | When only when profile was given (which is rarely), the itertools combination would not work, so a check was added, since all combinations of only one element is the element itself. |
| Animated GIF | -- |
