### PR TITLE
fix: add itertools file to basefiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Added `itertools.js` to gulpfile build files in order to be bundled
 
 ### Changed
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,6 +33,7 @@ const paths = {
         "src/js/base/errors.js",
         "src/js/base/observable.js",
         "src/js/base/interactable.js",
+        "src/js/base/itertools.js",
         "src/js/base/mobile.js",
         "src/js/base/ripe.js",
         "src/js/base/logic.js",


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Itertools methods were not present in the build file. Bug found in ripe-green. This one was fun to debug 🔪 🙃 |
| Dependencies | |
| Decisions | -- |
| Animated GIF | |
