### PR TITLE
#307: Disable masks if build contains "no_masks" tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added `itertools.js` to gulpfile build files in order to be bundled
 * Support for `no_masks` tag
 * `getPrices` which consumes `/api/config/prices` for getting prices for several configs in a single batch call
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Support for `no_masks` tag
 
 ### Changed
 

--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -173,6 +173,8 @@ ripe.ConfiguratorPrc.prototype.updateOptions = async function(options, update = 
         options.configAnimate === undefined ? this.configAnimate : options.configAnimate;
     this.viewAnimate = options.viewAnimate === undefined ? this.viewAnimate : options.viewAnimate;
 
+    this.useMasks = this.owner.brand && this.owner.hasTag("no_masks") ? false : this.useMasks;
+
     if (update) await this.update();
 };
 
@@ -1027,6 +1029,8 @@ ripe.ConfiguratorPrc.prototype._updateConfig = async function(animate) {
     // in case the element is no longer available (possible due to async
     // nature of execution) returns the control flow immediately
     if (!this.element) return;
+
+    this.useMasks = this.owner.brand && this.owner.hasTag("no_masks") ? false : this.useMasks;
 
     // sets ready to false to temporarily block
     // update requests while the new config

--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -731,7 +731,8 @@ ripe.ConfiguratorPrc.prototype.highlight = function(part, options = {}) {
 
     // if the 'useMasks' options is not set and the model has the "no_masks"
     // tag, then no masks are meant to be used
-    const useMasks = this.useMasks !== undefined && this.owner.hasTag("no_masks") ? false : this.useMasks;
+    const useMasks =
+        this.useMasks !== undefined && this.owner.hasTag("no_masks") ? false : this.useMasks;
 
     // verifiers if masks are meant to be used for the current model
     // and if that's not the case returns immediately
@@ -810,11 +811,12 @@ ripe.ConfiguratorPrc.prototype.lowlight = function(options) {
 
     // if the 'useMasks' options is not set and the model has the "no_masks"
     // tag, then no masks are meant to be used
-    const useMasks = this.useMasks !== undefined && this.owner.hasTag("no_masks") ? false : this.useMasks;
+    const useMasks =
+        this.useMasks !== undefined && this.owner.hasTag("no_masks") ? false : this.useMasks;
 
     // verifies if masks are meant to be used for the current model
     // and if that's not the case returns immediately
-    if (!this.useMasks) return;
+    if (!useMasks) return;
 
     // retrieves the reference to the current front mask and removes
     // the highlight associated classes from it and the configurator

--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -173,8 +173,6 @@ ripe.ConfiguratorPrc.prototype.updateOptions = async function(options, update = 
         options.configAnimate === undefined ? this.configAnimate : options.configAnimate;
     this.viewAnimate = options.viewAnimate === undefined ? this.viewAnimate : options.viewAnimate;
 
-    this.useMasks = this.owner.loadedConfig && this.owner.hasTag("no_masks") ? false : this.useMasks;
-
     if (update) await this.update();
 };
 
@@ -731,9 +729,13 @@ ripe.ConfiguratorPrc.prototype.highlight = function(part, options = {}) {
     // nature of execution) returns the control flow immediately
     if (!this.element) return;
 
+    // if the 'useMasks' options is not set and the model has the "no_masks"
+    // tag, then no masks are meant to be used
+    const useMasks = this.useMasks !== undefined && this.owner.hasTag("no_masks") ? false : this.useMasks;
+
     // verifiers if masks are meant to be used for the current model
     // and if that's not the case returns immediately
-    if (!this.useMasks) return;
+    if (!useMasks) return;
 
     // captures the current context to be used by clojure callbacks
     const self = this;
@@ -805,6 +807,10 @@ ripe.ConfiguratorPrc.prototype.lowlight = function(options) {
     // in case the element is no longer available (possible due to async
     // nature of execution) returns the control flow immediately
     if (!this.element) return;
+
+    // if the 'useMasks' options is not set and the model has the "no_masks"
+    // tag, then no masks are meant to be used
+    const useMasks = this.useMasks !== undefined && this.owner.hasTag("no_masks") ? false : this.useMasks;
 
     // verifies if masks are meant to be used for the current model
     // and if that's not the case returns immediately
@@ -1029,8 +1035,6 @@ ripe.ConfiguratorPrc.prototype._updateConfig = async function(animate) {
     // in case the element is no longer available (possible due to async
     // nature of execution) returns the control flow immediately
     if (!this.element) return;
-
-    this.useMasks = this.owner.loadedConfig && this.owner.hasTag("no_masks") ? false : this.useMasks;
 
     // sets ready to false to temporarily block
     // update requests while the new config

--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -173,7 +173,7 @@ ripe.ConfiguratorPrc.prototype.updateOptions = async function(options, update = 
         options.configAnimate === undefined ? this.configAnimate : options.configAnimate;
     this.viewAnimate = options.viewAnimate === undefined ? this.viewAnimate : options.viewAnimate;
 
-    this.useMasks = this.owner.brand && this.owner.hasTag("no_masks") ? false : this.useMasks;
+    this.useMasks = this.owner.loadedConfig && this.owner.hasTag("no_masks") ? false : this.useMasks;
 
     if (update) await this.update();
 };
@@ -1030,7 +1030,7 @@ ripe.ConfiguratorPrc.prototype._updateConfig = async function(animate) {
     // nature of execution) returns the control flow immediately
     if (!this.element) return;
 
-    this.useMasks = this.owner.brand && this.owner.hasTag("no_masks") ? false : this.useMasks;
+    this.useMasks = this.owner.loadedConfig && this.owner.hasTag("no_masks") ? false : this.useMasks;
 
     // sets ready to false to temporarily block
     // update requests while the new config


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-sdk/issues/307 |
| Dependencies | -- |
| Decisions | Checks if build contains `no_masks` tag and disables the masks in the configurator. It takes precendence over the options passed to the configurator. |
| Animated GIF | -- |

https://user-images.githubusercontent.com/25725586/131869488-8a8b28b1-1106-4a49-9cec-606c02118a6a.mp4
