### PR TITLE
feat: use config animate if update is made after config

### DIFF
--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -228,13 +228,24 @@ ripe.ConfiguratorPrc.prototype.update = async function(state, options = {}) {
         const duration = options.duration;
         const preload = options.preload;
 
-        // checks if the parts drawed on the target have
+        // checks if the parts drawn on the target have
         // changed and animates the transition if they did
         let previous = this.signature || "";
         const signature = this._buildSignature();
         const changed = signature !== previous;
-        const animate =
-            options.animate === undefined ? (changed ? "simple" : false) : options.animate;
+        let animate = options.animate;
+        if (animate === undefined) {
+            // if its the first update after a config change
+            // uses the configAnimate, else it uses a simple
+            // animation if there were changes in the parts
+            animate = previous
+                ? changed
+                    ? "simple"
+                    : false
+                : this.configAnimate === undefined
+                ? "simple"
+                : this.configAnimate;
+        }
         this.signature = signature;
 
         // if the parts and the position haven't changed

--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -236,7 +236,7 @@ ripe.ConfiguratorPrc.prototype.update = async function(state, options = {}) {
         let animate = options.animate;
         if (animate === undefined) {
             // if its the first update after a config change
-            // uses the configAnimate, else it uses a simple
+            // uses the config animate, else it uses a simple
             // animation if there were changes in the parts
             if (previous) animate = changed ? "simple" : false;
             else animate = this.configAnimate === undefined ? "simple" : this.configAnimate;

--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -238,13 +238,8 @@ ripe.ConfiguratorPrc.prototype.update = async function(state, options = {}) {
             // if its the first update after a config change
             // uses the configAnimate, else it uses a simple
             // animation if there were changes in the parts
-            animate = previous
-                ? changed
-                    ? "simple"
-                    : false
-                : this.configAnimate === undefined
-                ? "simple"
-                : this.configAnimate;
+            if (previous) animate = changed ? "simple" : false;
+            else animate = this.configAnimate === undefined ? "simple" : this.configAnimate;
         }
         this.signature = signature;
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | ConfigAnimate was not being used anywhere, making it impossible to disable the animation when first starting the configurator. (The last usage of configAnimate: https://github.com/ripe-tech/ripe-sdk/commit/eae86f176455956d5001d38747c2e579145b52d8#diff-44149027047186f90ca764a3b50eacce3ee815a9f66e73889332689a453b85bd) |
| Dependencies | -- |
| Decisions | - In the configurator `update` method, checks if no signature exists before (meaning that it's a new config), if that is the case, it uses the configAnimate to set the animation (if defined). |
| Animated GIF | **Before:**![green-config-before](https://user-images.githubusercontent.com/25725586/137885340-5d7e7b2d-847c-4961-affd-c10e5c677343.gif)<br>**Now:**<br>![Kapture 2021-10-19 at 10 39 56](https://user-images.githubusercontent.com/25725586/137884819-7c164d40-1246-4930-8145-2a2d1595065c.gif)|
