### PR TITLE
fix: explicitly add eslint-plugin-mocha dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
         "@babel/preset-env": "^7.14.4",
         "eslint": "^7.27.0",
         "eslint-config-hive": "^0.5.3",
+        "eslint-plugin-mocha": "^9.0.0",
         "fancy-log": "^1.3.3",
         "gulp": "^4.0.2",
         "gulp-babel": "^8.0.0",


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | CI is failing (https://github.com/ripe-tech/ripe-sdk/runs/3937347918) due to a npm@^8 bug (https://github.com/npm/cli/issues/3881), where there is inconsistencies in the install behaviour. This does not happen in previous versions and can be replicated locally only with npm@^8 installed. |
| Dependencies | -- |
| Decisions | - Explicitly add `eslint-plugin-mocha` dependency. |
| Animated GIF | -- |
