### PR TITLE
#263: `blockOrderP` to block an order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Support for the `Order` touch API endpoint
 * Support for `scale` in import order
 * Add test `should be able to set the price` in `#importOrder()` tests
+* Add `blockOrderP` and `blockOrder` methods to block an order - [#263](https://github.com/ripe-tech/ripe-pulse/issues/263)
 
 ### Changed
 

--- a/src/js/api/order.js
+++ b/src/js/api/order.js
@@ -747,6 +747,26 @@ ripe.Ripe.prototype.sendOrderP = function(number, trackingNumber, trackingUrl, o
 };
 
 /**
+ * Sets the order status to 'blocked'.
+ *
+ * @param {Number} number The number of the order to update.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
+ */
+ ripe.Ripe.prototype.blockOrder = function(number, options, callback) {
+    return this.setOrderStatus(number, "block", options, callback);
+};
+
+ripe.Ripe.prototype.blockOrderP = function(number, options) {
+    return new Promise((resolve, reject) => {
+        this.blockOrder(number, options, (result, isValid, request) => {
+            isValid ? resolve(result) : reject(new ripe.RemoteError(request, null, result));
+        });
+    });
+};
+
+/**
  * Sets the order status to 'receive'.
  *
  * @param {Number} number The number of the order to update.

--- a/src/js/api/order.js
+++ b/src/js/api/order.js
@@ -754,7 +754,7 @@ ripe.Ripe.prototype.sendOrderP = function(number, trackingNumber, trackingUrl, o
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
  */
- ripe.Ripe.prototype.blockOrder = function(number, options, callback) {
+ripe.Ripe.prototype.blockOrder = function(number, options, callback) {
     return this.setOrderStatus(number, "block", options, callback);
 };
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-pulse/issues/263 |
| Dependencies | https://github.com/ripe-tech/ripe-core/pull/4630 |
| Decisions | - Added `blockOrderP` method to block and order (status `blocked`). |
| Animated GIF | -- |