### PR TITLE
#312: Suport size in mask image request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Support for the `Order` touch API endpoint
 * Support for `scale` in import order
 * Add test `should be able to set the price` in `#importOrder()` tests
+* Support for `size` parameter in `_getMaskURL` request
 
 ### Changed
 

--- a/src/js/base/api.js
+++ b/src/js/base/api.js
@@ -1015,6 +1015,9 @@ ripe.Ripe.prototype._getMaskOptions = function(options = {}) {
     if (options.part !== undefined && options.part !== null) {
         params.part = options.part;
     }
+    if (options.size !== undefined && options.size !== null) {
+        params.size = options.size;
+    }
 
     const url = `${this.url}mask`;
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-sdk/issues/312 |
| Dependencies | -- |
| Decisions | - Support `size` param in mask image request `_getMaskURL` (ripe-white is already passing this parameter). |
| Animated GIF | Before:<br><img width="2559" alt="image" src="https://user-images.githubusercontent.com/25725586/139242069-6b6e822d-f338-4302-a081-8954ef4cd584.png"><br>Now:<br><img width="2560" alt="image" src="https://user-images.githubusercontent.com/25725586/139241720-d50f50ad-8840-4ce2-9ab6-8c43b7aca43b.png">|
