### PR TITLE
feat: add `setReturnTracking`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * `setTracking` method to the `Order` entity
+* `setReturnTracking` method to the `Order` entity
 * `setMeta` method allowing dynamic set of metadata attributes for the `Order` entity
 * Method for generating an image URL from a query (`_queryToImageUrl`)
 

--- a/src/js/api/order.js
+++ b/src/js/api/order.js
@@ -957,8 +957,8 @@ ripe.Ripe.prototype.setTrackingP = function(number, trackingNumber, trackingUrl,
  * Changes the return tracking info of an order.
  *
  * @param {Number} number The number of the order to change the return tracking info.
- * @param {String} trackingNumber The new return tracking number.
- * @param {String} trackingUrl The new return tracking URL.
+ * @param {String} returnTrackingNumber The new return tracking number.
+ * @param {String} returnTrackingUrl The new return tracking URL.
  * @param {Object} options An object of options to configure the request.
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
@@ -990,8 +990,8 @@ ripe.Ripe.prototype.setReturnTracking = function(
  * Changes the return tracking info of an order.
  *
  * @param {Number} number The number of the order to change the return tracking info.
- * @param {String} trackingNumber The new return tracking number.
- * @param {String} trackingUrl The new return tracking URL.
+ * @param {String} returnTrackingNumber The new return tracking number.
+ * @param {String} returnTrackingUrl The new return tracking URL.
  * @param {Object} options An object of options to configure the request.
  * @returns {Promise} The result of the order tracking info change.
  */

--- a/src/js/api/order.js
+++ b/src/js/api/order.js
@@ -954,6 +954,67 @@ ripe.Ripe.prototype.setTrackingP = function(number, trackingNumber, trackingUrl,
 };
 
 /**
+ * Changes the return tracking info of an order.
+ *
+ * @param {Number} number The number of the order to change the return tracking info.
+ * @param {String} trackingNumber The new return tracking number.
+ * @param {String} trackingUrl The new return tracking URL.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
+ */
+ripe.Ripe.prototype.setReturnTracking = function(
+    number,
+    returnTrackingNumber,
+    returnTrackingUrl,
+    options,
+    callback
+) {
+    callback = typeof options === "function" ? options : callback;
+    options = typeof options === "function" || options === undefined ? {} : options;
+    const url = `${this.url}orders/${number}/return_tracking`;
+    options = Object.assign(options, {
+        url: url,
+        method: "PUT",
+        auth: true,
+        params: {
+            return_tracking_number: returnTrackingNumber,
+            return_tracking_url: returnTrackingUrl
+        }
+    });
+    options = this._build(options);
+    return this._cacheURL(options.url, options, callback);
+};
+
+/**
+ * Changes the return tracking info of an order.
+ *
+ * @param {Number} number The number of the order to change the return tracking info.
+ * @param {String} trackingNumber The new return tracking number.
+ * @param {String} trackingUrl The new return tracking URL.
+ * @param {Object} options An object of options to configure the request.
+ * @returns {Promise} The result of the order tracking info change.
+ */
+ripe.Ripe.prototype.setTrackingP = function(
+    number,
+    returnTrackingNumber,
+    returnTrackingUrl,
+    options
+) {
+    return new Promise((resolve, reject) => {
+        this.setTracking(
+            number,
+            returnTrackingNumber,
+            returnTrackingUrl,
+            options,
+            (result, isValid, request) => {
+                isValid ? resolve(result) : reject(new ripe.RemoteError(request, null, result));
+            }
+        );
+    });
+};
+
+/**
  * Imports a production order to RIPE Core.
  *
  * @param {Number} ffOrderId The e-commerce order identifier.

--- a/src/js/api/order.js
+++ b/src/js/api/order.js
@@ -995,14 +995,14 @@ ripe.Ripe.prototype.setReturnTracking = function(
  * @param {Object} options An object of options to configure the request.
  * @returns {Promise} The result of the order tracking info change.
  */
-ripe.Ripe.prototype.setTrackingP = function(
+ripe.Ripe.prototype.setReturnTrackingP = function(
     number,
     returnTrackingNumber,
     returnTrackingUrl,
     options
 ) {
     return new Promise((resolve, reject) => {
-        this.setTracking(
+        this.setReturnTracking(
             number,
             returnTrackingNumber,
             returnTrackingUrl,


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/peri-shipping/issues/29 |
| Dependencies | https://github.com/ripe-tech/ripe-core/pull/4631 |
| Decisions | Replicate `setTracking` logic but for return tracking info. |
