### PR TITLE
feat: `setProofOfDelivery`  method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Add `setProofOfDeliveryP` and `setProofOfDelivery` methods to set proof of delivery info of an order - [#34](https://github.com/ripe-tech/peri-shipping/issues/34)
 
 ### Changed
 

--- a/src/js/api/order.js
+++ b/src/js/api/order.js
@@ -1071,6 +1071,47 @@ ripe.Ripe.prototype.setReturnTrackingP = function(
 };
 
 /**
+ * Changes the proof of delivery info of an order.
+ *
+ * @param {Number} number The number of the order to change the proof of delivery info.
+ * @param {String} proofOfDeliveryUrl The new proof of delivery URL.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
+ */
+ripe.Ripe.prototype.setProofOfDelivery = function(number, proofOfDeliveryUrl, options, callback) {
+    callback = typeof options === "function" ? options : callback;
+    options = typeof options === "function" || options === undefined ? {} : options;
+    const url = `${this.url}orders/${number}/proof_of_delivery`;
+    options = Object.assign(options, {
+        url: url,
+        method: "PUT",
+        auth: true,
+        params: {
+            proof_of_delivery_url: proofOfDeliveryUrl
+        }
+    });
+    options = this._build(options);
+    return this._cacheURL(options.url, options, callback);
+};
+
+/**
+ * Changes the proof of delivery info of an order.
+ *
+ * @param {Number} number The number of the order to change the proof of delivery info.
+ * @param {String} proofOfDeliveryUrl The new proof of delivery URL.
+ * @param {Object} options An object of options to configure the request.
+ * @returns {Promise} The result of the order proof of delivery info change.
+ */
+ripe.Ripe.prototype.setProofOfDeliveryP = function(number, proofOfDeliveryUrl, options) {
+    return new Promise((resolve, reject) => {
+        this.setProofOfDelivery(number, proofOfDeliveryUrl, options, (result, isValid, request) => {
+            isValid ? resolve(result) : reject(new ripe.RemoteError(request, null, result));
+        });
+    });
+};
+
+/**
  * Imports a production order to RIPE Core.
  *
  * @param {Number} ffOrderId The e-commerce order identifier.


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/peri-shipping/issues/34 |
| Dependencies | -- |
| Decisions | Add `setProofOfDeliveryP` and `setProofOfDelivery` methods |
