### PR TITLE
#4638 Locale size to native size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Add `localeToNative`, `localeToNativeP`, `localeToNativeB` and `localeToNativeBP` methods to convert locale sizes to native sizes and unit tests - [#4638](https://github.com/ripe-tech/ripe-core/issues/4638)
 
 ### Changed
 

--- a/src/js/api/size.js
+++ b/src/js/api/size.js
@@ -353,7 +353,7 @@ ripe.Ripe.prototype.nativeToLocaleBP = function(scales, values, genders, options
 
 /**
  * Converts a locale size value in the specified scale to the corresponding native size.
- * The available scales, genders and sizes can be obtained with the method getSizes.
+ * The available scales, genders and sizes can be obtained with the method `getSizes`.
  *
  * @param {String} scale The scale which one wants to convert from.
  * @param {Number} value The value which one wants to convert.
@@ -381,7 +381,7 @@ ripe.Ripe.prototype.localeToNative = function(scale, value, gender, options, cal
 
 /**
  * Converts a locale size value in the specified scale to the corresponding native size.
- * The available scales, genders and sizes can be obtained with the method getSizes.
+ * The available scales, genders and sizes can be obtained with the method `getSizes`.
  *
  * @param {String} scale The scale which one wants to convert from.
  * @param {Number} value The value which one wants to convert.
@@ -400,7 +400,7 @@ ripe.Ripe.prototype.localeToNativeP = function(scale, value, gender, options) {
 
 /**
  * Converts multiple locale size values to the corresponding native size.
- * The available scales, genders and sizes can be obtained with the method getSizes.
+ * The available scales, genders and sizes can be obtained with the method `getSizes`.
  *
  * @param {Array} scales A list of scales to convert from.
  * @param {Array} values A list of values to convert.
@@ -431,7 +431,7 @@ ripe.Ripe.prototype.localeToNativeB = function(scales, values, genders, options,
 
 /**
  * Converts multiple locale size values to the corresponding native size.
- * The available scales, genders and sizes can be obtained with the method getSizes.
+ * The available scales, genders and sizes can be obtained with the method `getSizes`.
  *
  * @param {Array} scales A list of scales to convert from.
  * @param {Array} values A list of values to convert.

--- a/src/js/api/size.js
+++ b/src/js/api/size.js
@@ -379,17 +379,6 @@ ripe.Ripe.prototype.localeToNative = function(scale, value, gender, options, cal
     return this._cacheURL(options.url, options, callback);
 };
 
-/**
- * Converts a locale size value in the specified scale to the corresponding native size.
- * The available scales, genders and sizes can be obtained with the method `getSizes`.
- *
- * @param {String} scale The scale which one wants to convert from.
- * @param {Number} value The value which one wants to convert.
- * @param {String} gender The gender of the scale and value to be converted.
- * @param {Object} options An object of options to configure the request.
- * @param {Function} callback Function with the result of the request.
- * @returns {Promise} The locale size converted to native size.
- */
 ripe.Ripe.prototype.localeToNativeP = function(scale, value, gender, options) {
     return new Promise((resolve, reject) => {
         this.localeToNative(scale, value, gender, options, (result, isValid, request) => {
@@ -429,17 +418,6 @@ ripe.Ripe.prototype.localeToNativeB = function(scales, values, genders, options,
     return this._cacheURL(options.url, options, callback);
 };
 
-/**
- * Converts multiple locale size values to the corresponding native size.
- * The available scales, genders and sizes can be obtained with the method `getSizes`.
- *
- * @param {Array} scales A list of scales to convert from.
- * @param {Array} values A list of values to convert.
- * @param {Array} genders A list of genders corresponding to the values.
- * @param {Object} options An object of options to configure the request.
- * @param {Function} callback Function with the result of the request.
- * @returns {Promise} Array withe the locale sizes converted to native sizes.
- */
 ripe.Ripe.prototype.localeToNativeBP = function(scales, values, genders, options) {
     return new Promise((resolve, reject) => {
         this.localeToNativeB(scales, values, genders, options, (result, isValid, request) => {

--- a/src/js/api/size.js
+++ b/src/js/api/size.js
@@ -379,6 +379,17 @@ ripe.Ripe.prototype.localeToNative = function(scale, value, gender, options, cal
     return this._cacheURL(options.url, options, callback);
 };
 
+/**
+ * Converts a locale size value in the specified scale to the corresponding native size.
+ * The available scales, genders and sizes can be obtained with the method getSizes.
+ *
+ * @param {String} scale The scale which one wants to convert from.
+ * @param {Number} value The value which one wants to convert.
+ * @param {String} gender The gender of the scale and value to be converted.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {Promise} The locale size converted to native size.
+ */
 ripe.Ripe.prototype.localeToNativeP = function(scale, value, gender, options) {
     return new Promise((resolve, reject) => {
         this.localeToNative(scale, value, gender, options, (result, isValid, request) => {
@@ -418,6 +429,17 @@ ripe.Ripe.prototype.localeToNativeB = function(scales, values, genders, options,
     return this._cacheURL(options.url, options, callback);
 };
 
+/**
+ * Converts multiple locale size values to the corresponding native size.
+ * The available scales, genders and sizes can be obtained with the method getSizes.
+ *
+ * @param {Array} scales A list of scales to convert from.
+ * @param {Array} values A list of values to convert.
+ * @param {Array} genders A list of genders corresponding to the values.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {Promise} Array withe the locale sizes converted to native sizes.
+ */
 ripe.Ripe.prototype.localeToNativeBP = function(scales, values, genders, options) {
     return new Promise((resolve, reject) => {
         this.localeToNativeB(scales, values, genders, options, (result, isValid, request) => {

--- a/src/js/api/size.js
+++ b/src/js/api/size.js
@@ -350,3 +350,78 @@ ripe.Ripe.prototype.nativeToLocaleBP = function(scales, values, genders, options
         });
     });
 };
+
+/**
+ * Converts a locake size value in the specified scale to the corresponding native size.
+ * The available scales, genders and sizes can be obtained with the method getSizes.
+ *
+ * @param {String} scale The scale which one wants to convert from.
+ * @param {Number} value The value which one wants to convert.
+ * @param {String} gender The gender of the scale and value to be converted.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
+ */
+ripe.Ripe.prototype.localeToNative = function(scale, value, gender, options, callback) {
+    callback = typeof options === "function" ? options : callback;
+    options = typeof options === "function" || options === undefined ? {} : options;
+    const url = `${this.url}sizes/locale_to_native`;
+    options = Object.assign(options, {
+        url: url,
+        method: "GET",
+        params: {
+            scale: scale,
+            value: value,
+            gender: gender
+        }
+    });
+    options = this._build(options);
+    return this._cacheURL(options.url, options, callback);
+};
+
+ripe.Ripe.prototype.localeToNativeP = function(scale, value, gender, options) {
+    return new Promise((resolve, reject) => {
+        this.localeToNative(scale, value, gender, options, (result, isValid, request) => {
+            isValid ? resolve(result) : reject(new ripe.RemoteError(request, null, result));
+        });
+    });
+};
+
+/**
+ * Converts multiple locale size values to the corresponding native size.
+ * The available scales, genders and sizes can be obtained with the method getSizes.
+ *
+ * @param {Array} scales A list of scales to convert from.
+ * @param {Array} values A list of values to convert.
+ * @param {Array} genders A list of genders corresponding to the values.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
+ */
+ripe.Ripe.prototype.localeToNativeB = function(scales, values, genders, options, callback) {
+    scales = typeof scales === "string" ? [scales] : scales;
+    values = typeof values === "string" ? [values] : values;
+    genders = typeof genders === "string" ? [genders] : genders;
+    callback = typeof options === "function" ? options : callback;
+    options = typeof options === "function" || options === undefined ? {} : options;
+    const url = `${this.url}sizes/locale_to_native_b`;
+    options = Object.assign(options, {
+        url: url,
+        method: "GET",
+        params: {
+            scales: scales,
+            values: values,
+            genders: genders
+        }
+    });
+    options = this._build(options);
+    return this._cacheURL(options.url, options, callback);
+};
+
+ripe.Ripe.prototype.localeToNativeBP = function(scales, values, genders, options) {
+    return new Promise((resolve, reject) => {
+        this.localeToNativeB(scales, values, genders, options, (result, isValid, request) => {
+            isValid ? resolve(result) : reject(new ripe.RemoteError(request, null, result));
+        });
+    });
+};

--- a/src/js/api/size.js
+++ b/src/js/api/size.js
@@ -352,7 +352,7 @@ ripe.Ripe.prototype.nativeToLocaleBP = function(scales, values, genders, options
 };
 
 /**
- * Converts a locake size value in the specified scale to the corresponding native size.
+ * Converts a locale size value in the specified scale to the corresponding native size.
  * The available scales, genders and sizes can be obtained with the method getSizes.
  *
  * @param {String} scale The scale which one wants to convert from.

--- a/test/js/api/size.js
+++ b/test/js/api/size.js
@@ -113,4 +113,51 @@ describe("SizeAPI", function() {
             assert.strictEqual(result[0].value, 42);
         });
     });
+
+    describe("#localeToNative()", function() {
+        it("should be able to convert sizes", async () => {
+            let result = null;
+
+            const remote = ripe.RipeAPI();
+
+            result = await remote.localeToNativeP("std:clothing", "XXL", "female");
+
+            assert.strictEqual(result.scale, "std:clothing");
+            assert.strictEqual(result.value, "XXL");
+            assert.strictEqual(result.gender, "female");
+            assert.strictEqual(result.native, 24);
+        });
+    });
+
+    describe("#localeToNativeB()", function() {
+        it("should be able to convert sizes in bulk", async () => {
+            let result = null;
+
+            const remote = ripe.RipeAPI();
+
+            result = await remote.localeToNativeBP(
+                ["std:clothing", "bag", "it", "std:clothing"],
+                ["XXL", "One Size", "38.5", "4 Yrs"],
+                ["female", "female", "male", "kids"]
+            );
+
+            assert.strictEqual(result.length, 4);
+            assert.strictEqual(result[0].scale, "std:clothing");
+            assert.strictEqual(result[0].value, "XXL");
+            assert.strictEqual(result[0].gender, "female");
+            assert.strictEqual(result[0].native, 24);
+            assert.strictEqual(result[1].scale, "bag");
+            assert.strictEqual(result[1].value, "One Size");
+            assert.strictEqual(result[1].gender, "female");
+            assert.strictEqual(result[1].native, 17);
+            assert.strictEqual(result[2].scale, "it");
+            assert.strictEqual(result[2].value, "8.5");
+            assert.strictEqual(result[2].gender, "male");
+            assert.strictEqual(result[2].native, 22);
+            assert.strictEqual(result[3].scale, "std:clothing");
+            assert.strictEqual(result[3].value, "4 Yrs");
+            assert.strictEqual(result[3].gender, "kids");
+            assert.strictEqual(result[3].native, 19);
+        });
+    });
 });

--- a/test/js/api/size.js
+++ b/test/js/api/size.js
@@ -151,7 +151,7 @@ describe("SizeAPI", function() {
             assert.strictEqual(result[1].gender, "female");
             assert.strictEqual(result[1].native, 17);
             assert.strictEqual(result[2].scale, "it");
-            assert.strictEqual(result[2].value, "8.5");
+            assert.strictEqual(result[2].value, "38.5");
             assert.strictEqual(result[2].gender, "male");
             assert.strictEqual(result[2].native, 22);
             assert.strictEqual(result[3].scale, "std:clothing");


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-core/issues/4638 |
| Dependencies | -- |
| Decisions | • Add `localeToNative`, `localeToNativeP`, `localeToNativeB ` and `localeToNativeBP` methodsto convert locale sizes to native sizes<br>• Add `#localeToNative()` and `#localeToNativeB()` tests  |
| Tests | ![imagem](https://user-images.githubusercontent.com/22588915/142650747-75d3f0d1-a531-43ba-9185-09a045736236.png) |
