### PR TITLE
test: fix brand getLogoP test

### DIFF
--- a/test/js/api/brand.js
+++ b/test/js/api/brand.js
@@ -15,7 +15,6 @@ describe("BrandAPI", function() {
                 brand: "dummy",
                 size: 50
             });
-            console.log(result.size);
             assert.strictEqual(result.size, 18381);
             assert.strictEqual(result.type, "image/png");
         });

--- a/test/js/api/brand.js
+++ b/test/js/api/brand.js
@@ -15,7 +15,8 @@ describe("BrandAPI", function() {
                 brand: "dummy",
                 size: 50
             });
-            assert.strictEqual(result.size, 20347);
+            console.log(result.size);
+            assert.strictEqual(result.size, 18381);
             assert.strictEqual(result.type, "image/png");
         });
     });


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Failing `getLogoP` test that changed the value size of the image returned:<br>
<img width="1422" alt="imagem" src="https://user-images.githubusercontent.com/25725586/143852509-7b897c53-ea3b-4fef-be38-3be9da58c1bf.png"><br> I still don't know what changed, the last change to the logo image in builds-static was 3 months ago. |
| Dependencies | -- |
| Decisions | -- |
| Animated GIF | -- |
