### PR TITLE
docs: add missing order methods documentation

### DIFF
--- a/src/js/api/order.js
+++ b/src/js/api/order.js
@@ -170,6 +170,14 @@ ripe.Ripe.prototype.deleteOrderP = function(number, options) {
     });
 };
 
+/**
+ * Returns all the attachments of an order.
+ *
+ * @param {Number} number The number of the order to find by.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
+ */
 ripe.Ripe.prototype.attachmentsOrder = function(number, options, callback) {
     callback = typeof options === "function" ? options : callback;
     options = typeof options === "function" || options === undefined ? {} : options;
@@ -183,6 +191,14 @@ ripe.Ripe.prototype.attachmentsOrder = function(number, options, callback) {
     return this._cacheURL(options.url, options, callback);
 };
 
+/**
+ * Returns all the attachments of an order.
+ *
+ * @param {Number} number The number of the order to find by.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {Promise} An object containing all the attachments of an order.
+ */
 ripe.Ripe.prototype.attachmentsOrderP = function(number, options) {
     return new Promise((resolve, reject) => {
         this.attachmentsOrder(number, options, (result, isValid, request) => {
@@ -191,6 +207,15 @@ ripe.Ripe.prototype.attachmentsOrderP = function(number, options) {
     });
 };
 
+/**
+ * Adds an attachment to an order.
+ *
+ * @param {Number} number The number of the order where the attachment will be added.
+ * @param {Object} file The attachment file to be added to the order.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
+ */
 ripe.Ripe.prototype.createAttachmentOrder = function(number, file, options, callback) {
     callback = typeof options === "function" ? options : callback;
     options = typeof options === "function" || options === undefined ? {} : options;
@@ -208,6 +233,15 @@ ripe.Ripe.prototype.createAttachmentOrder = function(number, file, options, call
     return this._cacheURL(options.url, options, callback);
 };
 
+/**
+ * Adds an attachment to an order.
+ *
+ * @param {Number} number The number of the order where the attachment will be added.
+ * @param {Object} file The attachment file to be added to the order.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {Promise} The attachment added to the order.
+ */
 ripe.Ripe.prototype.createAttachmentOrderP = function(number, file, options) {
     return new Promise((resolve, reject) => {
         this.createAttachmentOrder(number, file, options, (result, isValid, request) => {
@@ -216,6 +250,15 @@ ripe.Ripe.prototype.createAttachmentOrderP = function(number, file, options) {
     });
 };
 
+/**
+ * Returns the attachment of an order requested by ID.
+ *
+ * @param {Number} number The number of the order to find by.
+ * @param {Number} attachmentId The ID of the attachment of the order to find by.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
+ */
 ripe.Ripe.prototype.attachmentOrder = function(number, attachmentId, options, callback) {
     callback = typeof options === "function" ? options : callback;
     options = typeof options === "function" || options === undefined ? {} : options;
@@ -230,6 +273,15 @@ ripe.Ripe.prototype.attachmentOrder = function(number, attachmentId, options, ca
     return this._cacheURL(options.url, options, callback);
 };
 
+/**
+ * Returns the attachment of an order requested by ID.
+ *
+ * @param {Number} number The number of the order to find by.
+ * @param {Number} attachmentId The ID of the attachment of the order to find by.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {Promise} The attachment file of an order requested by ID.
+ */
 ripe.Ripe.prototype.attachmentOrderP = function(number, attachmentId, options) {
     return new Promise((resolve, reject) => {
         this.attachmentOrder(number, attachmentId, options, (result, isValid, request) => {
@@ -388,6 +440,14 @@ ripe.Ripe.prototype.refreshShippingOrderP = function(number, options) {
     });
 };
 
+/**
+ * Returns all the states (logs) of an order.
+ *
+ * @param {Number} number The number of the order to find by.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
+ */
 ripe.Ripe.prototype.logOrder = function(number, options, callback) {
     callback = typeof options === "function" ? options : callback;
     options = typeof options === "function" || options === undefined ? {} : options;
@@ -401,6 +461,14 @@ ripe.Ripe.prototype.logOrder = function(number, options, callback) {
     return this._cacheURL(options.url, options, callback);
 };
 
+/**
+ * Returns all the states of an order.
+ *
+ * @param {Number} number The number of the order to find by.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {Promise} The states of an order requested by number.
+ */
 ripe.Ripe.prototype.logOrderP = function(number, options) {
     return new Promise((resolve, reject) => {
         this.logOrder(number, options, (result, isValid, request) => {
@@ -409,6 +477,14 @@ ripe.Ripe.prototype.logOrderP = function(number, options) {
     });
 };
 
+/**
+ * Returns all the states of an order.
+ *
+ * @param {Number} number The number of the order to find by.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
+ */
 ripe.Ripe.prototype.statesOrder = function(number, options, callback) {
     callback = typeof options === "function" ? options : callback;
     options = typeof options === "function" || options === undefined ? {} : options;
@@ -422,6 +498,14 @@ ripe.Ripe.prototype.statesOrder = function(number, options, callback) {
     return this._cacheURL(options.url, options, callback);
 };
 
+/**
+ * Returns all the states of an order.
+ *
+ * @param {Number} number The number of the order to find by.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {Promise} The states of an order requested by number.
+ */
 ripe.Ripe.prototype.statesOrderP = function(number, options) {
     return new Promise((resolve, reject) => {
         this.statesOrder(number, options, (result, isValid, request) => {
@@ -430,6 +514,15 @@ ripe.Ripe.prototype.statesOrderP = function(number, options) {
     });
 };
 
+/**
+ * Returns the state of an order.
+ *
+ * @param {Number} number The number of the order to find by.
+ * @param {Number} stateId The ID of the state of the order to find by.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
+ */
 ripe.Ripe.prototype.stateOrder = function(number, stateId, options, callback) {
     callback = typeof options === "function" ? options : callback;
     options = typeof options === "function" || options === undefined ? {} : options;
@@ -443,6 +536,15 @@ ripe.Ripe.prototype.stateOrder = function(number, stateId, options, callback) {
     return this._cacheURL(options.url, options, callback);
 };
 
+/**
+ * Returns the state of an order.
+ *
+ * @param {Number} number The number of the order to find by.
+ * @param {Number} stateId The ID of the state of the order to find by.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {Promise} The state requested by ID.
+ */
 ripe.Ripe.prototype.stateOrderP = function(number, stateId, options) {
     return new Promise((resolve, reject) => {
         this.stateOrder(number, stateId, options, (result, isValid, request) => {
@@ -451,6 +553,15 @@ ripe.Ripe.prototype.stateOrderP = function(number, stateId, options) {
     });
 };
 
+/**
+ * Returns the chat name and lines of an order for a specific state.
+ *
+ * @param {Number} number The number of the order to find by.
+ * @param {Number} stateId The ID of the state of the order to find by.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
+ */
 ripe.Ripe.prototype.stateChatOrder = function(number, stateId, options, callback) {
     callback = typeof options === "function" ? options : callback;
     options = typeof options === "function" || options === undefined ? {} : options;
@@ -465,6 +576,15 @@ ripe.Ripe.prototype.stateChatOrder = function(number, stateId, options, callback
     return this._cacheURL(options.url, options, callback);
 };
 
+/**
+ * Returns the chat name and lines of an order for a specific state.
+ *
+ * @param {Number} number The number of the order to find by.
+ * @param {Number} stateId The ID of the state of the order to find by.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {Promise} An object containing the chat name and lines for a specific state.
+ */
 ripe.Ripe.prototype.stateChatOrderP = function(number, stateId, options) {
     return new Promise((resolve, reject) => {
         this.stateChatOrder(number, stateId, options, (result, isValid, request) => {
@@ -473,6 +593,15 @@ ripe.Ripe.prototype.stateChatOrderP = function(number, stateId, options) {
     });
 };
 
+/**
+ * Returns all the chat lines of an order for a specific state.
+ *
+ * @param {Number} number The number of the order to find by.
+ * @param {Number} stateId The ID of the state of the order to find by.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
+ */
 ripe.Ripe.prototype.stateChatLinesOrder = function(number, stateId, options, callback) {
     callback = typeof options === "function" ? options : callback;
     options = typeof options === "function" || options === undefined ? {} : options;
@@ -487,6 +616,15 @@ ripe.Ripe.prototype.stateChatLinesOrder = function(number, stateId, options, cal
     return this._cacheURL(options.url, options, callback);
 };
 
+/**
+ * Returns all the chat lines of an order for a specific state.
+ *
+ * @param {Number} number The number of the order to find by.
+ * @param {Number} stateId The ID of the state of the order to find by.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {Promise} An object containing the chat lines for a specific state.
+ */
 ripe.Ripe.prototype.stateChatLinesOrderP = function(number, stateId, options) {
     return new Promise((resolve, reject) => {
         this.stateChatOrder(number, stateId, options, (result, isValid, request) => {
@@ -495,6 +633,15 @@ ripe.Ripe.prototype.stateChatLinesOrderP = function(number, stateId, options) {
     });
 };
 
+/**
+ * Returns the number of chat lines of an order for a specific state.
+ *
+ * @param {Number} number The number of the order to find by.
+ * @param {Number} stateId The ID of the state of the order to find by.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
+ */
 ripe.Ripe.prototype.stateChatLinesCountOrder = function(number, stateId, options, callback) {
     callback = typeof options === "function" ? options : callback;
     options = typeof options === "function" || options === undefined ? {} : options;
@@ -509,6 +656,15 @@ ripe.Ripe.prototype.stateChatLinesCountOrder = function(number, stateId, options
     return this._cacheURL(options.url, options, callback);
 };
 
+/**
+ * Returns the number of chat lines of an order for a specific state.
+ *
+ * @param {Number} number The number of the order to find by.
+ * @param {Number} stateId The ID of the state of the order to find by.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {Promise} An object containing the number of chat lines for a specific state.
+ */
 ripe.Ripe.prototype.stateChatLinesCountOrderP = function(number, stateId, options) {
     return new Promise((resolve, reject) => {
         this.stateChatLinesCountOrder(number, stateId, options, (result, isValid, request) => {
@@ -517,6 +673,16 @@ ripe.Ripe.prototype.stateChatLinesCountOrderP = function(number, stateId, option
     });
 };
 
+/**
+ * Adds a new chat line message to a specific order for a specific state.
+ *
+ * @param {Number} number The number of the order where the chat line message will be added.
+ * @param {Number} stateId The ID of the state of the order where the chat line message will be added.
+ * @param {Object} contents The contents of the chat message.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
+ */
 ripe.Ripe.prototype.stateChatCreateLineOrder = function(
     number,
     stateId,
@@ -539,6 +705,16 @@ ripe.Ripe.prototype.stateChatCreateLineOrder = function(
     return this._cacheURL(options.url, options, callback);
 };
 
+/**
+ * Adds a new chat line message to a specific order for a specific state.
+ *
+ * @param {Number} number The number of the order where the chat line message will be added.
+ * @param {Number} stateId The ID of the state of the order where the chat line message will be added.
+ * @param {Object} contents The contents of the chat message.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {Promise} An object containing the chat lines for the specific state.
+ */
 ripe.Ripe.prototype.stateChatCreateLineOrderP = function(number, stateId, contents, options) {
     return new Promise((resolve, reject) => {
         this.stateChatCreateLineOrder(
@@ -553,6 +729,15 @@ ripe.Ripe.prototype.stateChatCreateLineOrderP = function(number, stateId, conten
     });
 };
 
+/**
+ * Returns all the attachments of an order for a specific state.
+ *
+ * @param {Number} number The number of the order to find by.
+ * @param {Number} stateId The ID of the state of the order to find by.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
+ */
 ripe.Ripe.prototype.stateAttachmentsOrder = function(number, stateId, options, callback) {
     callback = typeof options === "function" ? options : callback;
     options = typeof options === "function" || options === undefined ? {} : options;
@@ -567,6 +752,15 @@ ripe.Ripe.prototype.stateAttachmentsOrder = function(number, stateId, options, c
     return this._cacheURL(options.url, options, callback);
 };
 
+/**
+ * Returns all the attachments of an order for a specific state.
+ *
+ * @param {Number} number The number of the order to find by.
+ * @param {Number} stateId The ID of the state of the order to find by.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {Promise} All the attachments of a specific order and state.
+ */
 ripe.Ripe.prototype.stateAttachmentsOrderP = function(number, stateId, options) {
     return new Promise((resolve, reject) => {
         this.stateAttachmentsOrder(number, stateId, options, (result, isValid, request) => {
@@ -575,6 +769,15 @@ ripe.Ripe.prototype.stateAttachmentsOrderP = function(number, stateId, options) 
     });
 };
 
+/**
+ * Returns the number of attachments of an order for a specific state.
+ *
+ * @param {Number} number The number of the order to find by.
+ * @param {Number} stateId The ID of the state of the order to find by.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
+ */
 ripe.Ripe.prototype.stateAttachmentsCountOrder = function(number, stateId, options, callback) {
     callback = typeof options === "function" ? options : callback;
     options = typeof options === "function" || options === undefined ? {} : options;
@@ -589,6 +792,15 @@ ripe.Ripe.prototype.stateAttachmentsCountOrder = function(number, stateId, optio
     return this._cacheURL(options.url, options, callback);
 };
 
+/**
+ * Returns the number of attachments of an order for a specific state.
+ *
+ * @param {Number} number The number of the order to find by.
+ * @param {Number} stateId The ID of the state of the order to find by.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {Promise} An object containing the number of attachments.
+ */
 ripe.Ripe.prototype.stateAttachmentsCountOrderP = function(number, stateId, options) {
     return new Promise((resolve, reject) => {
         this.stateAttachmentsCountOrder(number, stateId, options, (result, isValid, request) => {
@@ -597,6 +809,15 @@ ripe.Ripe.prototype.stateAttachmentsCountOrderP = function(number, stateId, opti
     });
 };
 
+/**
+ * Adds an attachment to an order for a specific state.
+ *
+ * @param {Number} number The number of the order to add the attachment to.
+ * @param {Number} stateId The ID of the state of the order to add the attachment to.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
+ */
 ripe.Ripe.prototype.stateCreateAttachmentOrder = function(
     number,
     stateId,
@@ -620,6 +841,15 @@ ripe.Ripe.prototype.stateCreateAttachmentOrder = function(
     return this._cacheURL(options.url, options, callback);
 };
 
+/**
+ * Adds an attachment to an order for a specific state.
+ *
+ * @param {Number} number The number of the order to add the attachment to.
+ * @param {Number} stateId The ID of the state of the order to add the attachment to.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {Promise} The attachment added.
+ */
 ripe.Ripe.prototype.stateCreateAttachmentOrderP = function(number, stateId, file, options) {
     return new Promise((resolve, reject) => {
         this.stateCreateAttachmentOrder(
@@ -634,6 +864,16 @@ ripe.Ripe.prototype.stateCreateAttachmentOrderP = function(number, stateId, file
     });
 };
 
+/**
+ * Gets the attachment with a specific ID of an order for a specific state.
+ *
+ * @param {Number} number The number of the order to find by.
+ * @param {Number} stateId The ID of the state of the order to find by.
+ * @param {Number} attachmentId The ID of the attachment to find.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
+ */
 ripe.Ripe.prototype.stateAttachmentOrder = function(
     number,
     stateId,
@@ -654,6 +894,16 @@ ripe.Ripe.prototype.stateAttachmentOrder = function(
     return this._cacheURL(options.url, options, callback);
 };
 
+/**
+ * Gets the attachment with a specific ID of an order for a specific state.
+ *
+ * @param {Number} number The number of the order to find by.
+ * @param {Number} stateId The ID of the state of the order to find by.
+ * @param {Number} attachmentId The ID of the attachment to find.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {Promise} The attachment file requested by ID.
+ */
 ripe.Ripe.prototype.stateAttachmentOrderP = function(number, stateId, attachmentId, options) {
     return new Promise((resolve, reject) => {
         this.stateAttachmentOrder(

--- a/src/js/api/order.js
+++ b/src/js/api/order.js
@@ -725,6 +725,14 @@ ripe.Ripe.prototype.createOrder = function(number, options, callback) {
     return this.setOrderStatus(number, "create", options, callback);
 };
 
+/**
+ * Sets the order status to 'create'.
+ *
+ * @param {Number} number The number of the order to update.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {Promise} The order with the updated status.
+ */
 ripe.Ripe.prototype.createOrderP = function(number, options) {
     return new Promise((resolve, reject) => {
         this.createOrder(number, options, (result, isValid, request) => {
@@ -745,6 +753,14 @@ ripe.Ripe.prototype.produceOrder = function(number, options, callback) {
     return this.setOrderStatus(number, "produce", options, callback);
 };
 
+/**
+ * Sets the order status to 'produce'.
+ *
+ * @param {Number} number The number of the order to update.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {Promise} The order with the updated status.
+ */
 ripe.Ripe.prototype.produceOrderP = function(number, options) {
     return new Promise((resolve, reject) => {
         this.produceOrder(number, options, (result, isValid, request) => {
@@ -765,6 +781,14 @@ ripe.Ripe.prototype.qualityAssureOrder = function(number, options, callback) {
     return this.setOrderStatus(number, "quality_assure", options, callback);
 };
 
+/**
+ * Sets the order status to 'quality_assure'.
+ *
+ * @param {Number} number The number of the order to update.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {Promise} The order with the updated status.
+ */
 ripe.Ripe.prototype.qualityAssureOrderP = function(number, options) {
     return new Promise((resolve, reject) => {
         this.qualityAssureOrder(number, options, (result, isValid, request) => {
@@ -785,6 +809,14 @@ ripe.Ripe.prototype.rejectOrder = function(number, options, callback) {
     return this.setOrderStatus(number, "reject", options, callback);
 };
 
+/**
+ * Sets the order status to 'reject'.
+ *
+ * @param {Number} number The number of the order to update.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {Promise} The order with the updated status.
+ */
 ripe.Ripe.prototype.rejectOrderP = function(number, options) {
     return new Promise((resolve, reject) => {
         this.rejectOrder(number, options, (result, isValid, request) => {
@@ -805,6 +837,14 @@ ripe.Ripe.prototype.readyOrder = function(number, options, callback) {
     return this.setOrderStatus(number, "ready", options, callback);
 };
 
+/**
+ * Sets the order status to 'ready'.
+ *
+ * @param {Number} number The number of the order to update.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {Promise} The order with the updated status.
+ */
 ripe.Ripe.prototype.readyOrderP = function(number, options) {
     return new Promise((resolve, reject) => {
         this.readyOrder(number, options, (result, isValid, request) => {
@@ -813,6 +853,14 @@ ripe.Ripe.prototype.readyOrderP = function(number, options) {
     });
 };
 
+/**
+ * Sets the order status to 'sent'.
+ *
+ * @param {Number} number The number of the order to update.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
+ */
 ripe.Ripe.prototype.sendOrder = function(number, trackingNumber, trackingUrl, options, callback) {
     callback = typeof options === "function" ? options : callback;
     options = typeof options === "function" || options === undefined ? {} : options;
@@ -825,6 +873,14 @@ ripe.Ripe.prototype.sendOrder = function(number, trackingNumber, trackingUrl, op
     return this.setOrderStatus(number, "send", options, callback);
 };
 
+/**
+ * Sets the order status to 'sent'.
+ *
+ * @param {Number} number The number of the order to update.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {Promise} The order with the updated status.
+ */
 ripe.Ripe.prototype.sendOrderP = function(number, trackingNumber, trackingUrl, options) {
     return new Promise((resolve, reject) => {
         this.sendOrder(number, trackingNumber, trackingUrl, options, (result, isValid, request) => {
@@ -845,6 +901,14 @@ ripe.Ripe.prototype.blockOrder = function(number, options, callback) {
     return this.setOrderStatus(number, "block", options, callback);
 };
 
+/**
+ * Sets the order status to 'blocked'.
+ *
+ * @param {Number} number The number of the order to update.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {Promise} The order with the updated status.
+ */
 ripe.Ripe.prototype.blockOrderP = function(number, options) {
     return new Promise((resolve, reject) => {
         this.blockOrder(number, options, (result, isValid, request) => {
@@ -865,6 +929,14 @@ ripe.Ripe.prototype.receiveOrder = function(number, options, callback) {
     return this.setOrderStatus(number, "receive", options, callback);
 };
 
+/**
+ * Sets the order status to 'receive'.
+ *
+ * @param {Number} number The number of the order to update.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {Promise} The order with the updated status.
+ */
 ripe.Ripe.prototype.receiveOrderP = function(number, options) {
     return new Promise((resolve, reject) => {
         this.receiveOrder(number, options, (result, isValid, request) => {
@@ -885,6 +957,14 @@ ripe.Ripe.prototype.returnOrder = function(number, options, callback) {
     return this.setOrderStatus(number, "return", options, callback);
 };
 
+/**
+ * Sets the order status to 'return'.
+ *
+ * @param {Number} number The number of the order to update.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {Promise} The order with the updated status.
+ */
 ripe.Ripe.prototype.returnOrderP = function(number, options) {
     return new Promise((resolve, reject) => {
         this.returnOrder(number, options, (result, isValid, request) => {
@@ -905,6 +985,14 @@ ripe.Ripe.prototype.cancelOrder = function(number, options, callback) {
     return this.setOrderStatus(number, "cancel", options, callback);
 };
 
+/**
+ * Sets the order status to 'cancel'.
+ *
+ * @param {Number} number The number of the order to update.
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {Promise} The order with the updated status.
+ */
 ripe.Ripe.prototype.cancelOrderP = function(number, options) {
     return new Promise((resolve, reject) => {
         this.cancelOrder(number, options, (result, isValid, request) => {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-sdk/pull/329/files/c11f261d7d5d3b9ccf74aaefe4379967c2fbed28#r758316960 |
| Dependencies | -- |
| Decisions | Added missing documentation for order methods. |
| Animated GIF | -- |
