### PR TITLE
#948: Use pixel ratio in image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Use pixel ratio in image - [ripe-white/#948](https://github.com/ripe-tech/ripe-white/issues/948)
 
 ### Changed
 

--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -63,8 +63,10 @@ ripe.ConfiguratorPrc.prototype.init = function() {
     this.size = this.options.size || null;
     this.mutations = this.options.mutations || false;
     this.maxSize = this.options.maxSize || 1000;
+    this.usePixelRatio = this.options.usePixelRatio || false;
     this.pixelRatio =
-        this.options.pixelRatio || (typeof window !== "undefined" && window.devicePixelRatio) || 2;
+        this.options.pixelRatio ||
+        (this.usePixelRatio ? (typeof window !== "undefined" && window.devicePixelRatio) || 2 : 1);
     this.sensitivity = this.options.sensitivity || 40;
     this.verticalThreshold = this.options.verticalThreshold || 15;
     this.clickThreshold = this.options.clickThreshold || 0.015;
@@ -170,7 +172,7 @@ ripe.ConfiguratorPrc.prototype.updateOptions = async function(options, update = 
     this.size = options.size === undefined ? this.size : options.size;
     this.mutations = options.mutations === undefined ? this.mutations : options.mutations;
     this.maxSize = options.maxSize === undefined ? this.maxSize : this.maxSize;
-    this.pixelRatio = options.pixelRation === undefined ? this.pixelRatio : options.pixelRatio;
+    this.pixelRatio = options.pixelRatio === undefined ? this.pixelRatio : options.pixelRatio;
     this.sensitivity = options.sensitivity === undefined ? this.sensitivity : options.sensitivity;
     this.verticalThreshold =
         options.verticalThreshold === undefined

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -270,6 +270,7 @@ ripe.Image.prototype.update = async function(state, options = {}) {
         const size = this.element.dataset.size || this.size;
         const width = this.element.dataset.width || this.width;
         const height = this.element.dataset.height || this.height;
+        const pixelRatio = this.element.dataset.pixelRatio || this.pixelRatio;
         const rotation = this.element.dataset.rotation || this.rotation;
         const crop = this.element.dataset.crop || this.crop;
         const initialsGroup = this.element.dataset.initialsGroup || this.initialsGroup;
@@ -366,9 +367,9 @@ ripe.Image.prototype.update = async function(state, options = {}) {
         const url = this.owner._getImageURL({
             frame: frame,
             format: format,
-            size: size * this.pixelRatio,
-            width: width * this.pixelRatio,
-            height: height * this.pixelRatio,
+            size: size ? size * pixelRatio : size,
+            width: width ? width * pixelRatio : width,
+            height: height ? height * pixelRatio : height,
             rotation: rotation,
             crop: crop,
             initials: initialsSpec.initials,

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -53,6 +53,8 @@ ripe.Image.prototype.init = function() {
     this.size = this.options.size || null;
     this.width = this.options.width || null;
     this.height = this.options.height || null;
+    this.pixelRatio =
+        this.options.pixelRatio || (typeof window !== "undefined" && window.devicePixelRatio) || 2;
     this.mutations = this.options.mutations || false;
     this.rotation = this.options.rotation || null;
     this.crop = this.options.crop || null;
@@ -146,6 +148,7 @@ ripe.Image.prototype.updateOptions = async function(options, update = true) {
     this.size = options.size === undefined ? this.size : options.size;
     this.width = options.width === undefined ? this.width : options.width;
     this.height = options.height === undefined ? this.height : options.height;
+    this.pixelRatio = options.pixelRation === undefined ? this.pixelRatio : options.pixelRatio;
     this.rotation = options.rotation === undefined ? this.rotation : options.rotation;
     this.crop = options.crop === undefined ? this.crop : options.crop;
     this.flip = options.flip === undefined ? this.flip : options.flip;
@@ -363,9 +366,9 @@ ripe.Image.prototype.update = async function(state, options = {}) {
         const url = this.owner._getImageURL({
             frame: frame,
             format: format,
-            size: size,
-            width: width,
-            height: height,
+            size: size * this.pixelRatio,
+            width: width * this.pixelRatio,
+            height: height * this.pixelRatio,
             rotation: rotation,
             crop: crop,
             initials: initialsSpec.initials,


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/948 |
| Dependencies | -- |
| Decisions | -- |
| Animated GIF | Comparison (left is sbx): ![image](https://user-images.githubusercontent.com/25725586/149177875-e5b77ad1-a639-4d94-adf2-817863c99140.png)|
