### PR TITLE
fix: move usePixelRatio logic to image instead of configurator

### DIFF
--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -63,10 +63,8 @@ ripe.ConfiguratorPrc.prototype.init = function() {
     this.size = this.options.size || null;
     this.mutations = this.options.mutations || false;
     this.maxSize = this.options.maxSize || 1000;
-    this.usePixelRatio = this.options.usePixelRatio || false;
     this.pixelRatio =
-        this.options.pixelRatio ||
-        (this.usePixelRatio ? (typeof window !== "undefined" && window.devicePixelRatio) || 2 : 1);
+        this.options.pixelRatio || (typeof window !== "undefined" && window.devicePixelRatio) || 2;
     this.sensitivity = this.options.sensitivity || 40;
     this.verticalThreshold = this.options.verticalThreshold || 15;
     this.clickThreshold = this.options.clickThreshold || 0.015;

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -53,8 +53,10 @@ ripe.Image.prototype.init = function() {
     this.size = this.options.size || null;
     this.width = this.options.width || null;
     this.height = this.options.height || null;
+    this.usePixelRatio = this.options.usePixelRatio || false;
     this.pixelRatio =
-        this.options.pixelRatio || (typeof window !== "undefined" && window.devicePixelRatio) || 2;
+        this.options.pixelRatio ||
+        (this.usePixelRatio ? (typeof window !== "undefined" && window.devicePixelRatio) || 2 : 1);
     this.mutations = this.options.mutations || false;
     this.rotation = this.options.rotation || null;
     this.crop = this.options.crop || null;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | `usePixelRatio` was in configurator instead of image (my bad) |
| Dependencies | -- |
| Decisions | -- |
| Animated GIF | -- |
