### PR TITLE
fix: convert image size and width height to ints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Fixed non integer aspect ratio in image
 
 ## [2.15.0] - 2022-01-12
 

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -367,9 +367,9 @@ ripe.Image.prototype.update = async function(state, options = {}) {
         const url = this.owner._getImageURL({
             frame: frame,
             format: format,
-            size: parseInt(size ? size * pixelRatio : size),
-            width: parseInt(width ? width * pixelRatio : width),
-            height: parseInt(height ? height * pixelRatio : height),
+            size: size ? parseInt(size * pixelRatio) : size,
+            width: width ? parseInt(width * pixelRatio) : width,
+            height: height ? parseInt(height * pixelRatio) : height,
             rotation: rotation,
             crop: crop,
             initials: initialsSpec.initials,

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -367,9 +367,9 @@ ripe.Image.prototype.update = async function(state, options = {}) {
         const url = this.owner._getImageURL({
             frame: frame,
             format: format,
-            size: size ? size * pixelRatio : size,
-            width: width ? width * pixelRatio : width,
-            height: height ? height * pixelRatio : height,
+            size: parseInt(size ? size * pixelRatio : size),
+            width: parseInt(width ? width * pixelRatio : width),
+            height: parseInt(height ? height * pixelRatio : height),
             rotation: rotation,
             crop: crop,
             initials: initialsSpec.initials,


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | In computers with non-int pixel ratio, this occured (width is float):<br><img width="1345" alt="imagem" src="https://user-images.githubusercontent.com/25725586/149817293-f04312cd-a62c-407a-8992-20ad3d3bc668.png"><br><img width="1165" alt="imagem" src="https://user-images.githubusercontent.com/25725586/149817360-e7dc86ba-752b-4056-b238-2c00f2a841a0.png"> |
| Dependencies | -- |
| Decisions | - Convert image `size` and `width` and `height` to ints, since compose only supports ints. |
| Animated GIF | -- |
