### PR TITLE
fix: remove default width and height for configurator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Remove default width and height for configurator-prc
 
 ## [2.15.0] - 2022-01-12
 

--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -57,8 +57,8 @@ ripe.ConfiguratorPrc.prototype.constructor = ripe.ConfiguratorPrc;
 ripe.ConfiguratorPrc.prototype.init = function() {
     ripe.Visual.prototype.init.call(this);
 
-    this.width = this.options.width || 1000;
-    this.height = this.options.height || 1000;
+    this.width = this.options.width || null;
+    this.height = this.options.height || null;
     this.format = this.options.format || null;
     this.size = this.options.size || null;
     this.mutations = this.options.mutations || false;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Since the width and height are set has default, it did not defaulted to the clientWidth (space available) of the configurator element, which caused regressions on ripe-green:<br>![imagem](https://user-images.githubusercontent.com/25725586/149818458-39d21c29-7c64-4db4-a4c9-ee20a16f0589.png)<br>https://github.com/ripe-tech/ripe-green/pull/113#issuecomment-1014477503 |
| Dependencies | -- |
| Decisions | - Remove default width and height of the configurator. |
| Animated GIF | Now:<br><img width="950" alt="imagem" src="https://user-images.githubusercontent.com/25725586/149818811-5a0e7664-7f72-4e35-ae72-98959393fa5a.png">|
