### PR TITLE
fix: proper method name for `signinPidP`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Fixed method name for `signinPidP`
 
 ## [2.16.0] - 2022-01-24
 

--- a/src/js/base/api.js
+++ b/src/js/base/api.js
@@ -190,7 +190,7 @@ ripe.Ripe.prototype.signinPid = function(token, options, callback) {
 
 ripe.Ripe.prototype.signinPidP = function(token, options) {
     return new Promise((resolve, reject) => {
-        this.signinAdmin(token, options, (result, isValid, request) => {
+        this.signinPid(token, options, (result, isValid, request) => {
             isValid ? resolve(result) : reject(new ripe.RemoteError(request, null, result));
         });
     });


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | `signinPidP` is calling `signinAdmin` when it should be calling `signinPid`. |
| Decisions | - Fix method call to `signinPid`. |
