### PR TITLE
fix: use same linting directories for prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "lint": "gulp lint",
         "lint-fix": "gulp lint-fix",
         "mark": "gulp mark",
-        "prettier": "prettier \"./*.{js,ts,json}\" \"./{src,test,types}/**/*.{js,ts,json}\" --write",
+        "prettier": "prettier \"./*.{js,ts,json}\" \"./src/js/**/*.{js,ts,json}\" \"./{test,types}/**/*.{js,ts,json}\" --write",
         "pretty": "npm run prettier && npm run lint-fix",
         "test": "gulp test",
         "upgrade": "npx sort-package-json && ncu -u",

--- a/src/js/api/order.js
+++ b/src/js/api/order.js
@@ -1468,12 +1468,7 @@ ripe.Ripe.prototype.setReturnTrackingP = function(
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
  */
- ripe.Ripe.prototype.setPickup = function(
-    number,
-    pickupNumber,
-    options,
-    callback
-) {
+ripe.Ripe.prototype.setPickup = function(number, pickupNumber, options, callback) {
     callback = typeof options === "function" ? options : callback;
     options = typeof options === "function" || options === undefined ? {} : options;
     const url = `${this.url}orders/${number}/pickup_number`;
@@ -1497,20 +1492,11 @@ ripe.Ripe.prototype.setReturnTrackingP = function(
  * @param {Object} options An object of options to configure the request.
  * @returns {Promise} The result of the order tracking info change.
  */
- ripe.Ripe.prototype.setPickupP = function(
-    number,
-    pickupNumber,
-    options
-) {
+ripe.Ripe.prototype.setPickupP = function(number, pickupNumber, options) {
     return new Promise((resolve, reject) => {
-        this.setPickup(
-            number,
-            pickupNumber,
-            options,
-            (result, isValid, request) => {
-                isValid ? resolve(result) : reject(new ripe.RemoteError(request, null, result));
-            }
-        );
+        this.setPickup(number, pickupNumber, options, (result, isValid, request) => {
+            isValid ? resolve(result) : reject(new ripe.RemoteError(request, null, result));
+        });
     });
 };
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Related to https://github.com/ripe-tech/ripe-sdk/pull/360 |
| Dependencies | -- |
| Decisions | - In the linting setup in `gulpfile`, only the `src/js` files are being analyzed. In prettier the `js` files inside `src/python` were also being analyzed, which caused changes that do not reflect our linting standards to be made each time we ran `yarn pretty`. -> The same logic present in `gulpfile` was applied to prettier. If we made the contrary, several changes would need to be made to make `src/python/ripe_demo/static/js/main.js` compliant to our linting standards. |
| Animated GIF | -- |
