### PR TITLE
#357 Debouncer for setting the initials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Add create order bulk methods - [ripe-pulse/#281](https://github.com/ripe-tech/ripe-pulse/issues/281)
+* Add debouncer `initialsDebounce` defaulting to 275 for `setInitials` and `setInitialsExtra` methods - [#357](https://github.com/ripe-tech/ripe-sdk/issues/357)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ if (ripe.isOAuthPending()) {
 | `usePrice`                | *boolean*          | Enables the fetch price feature every time a new part is set. True by default.                                                                                                             |
 | `useSync`                 | *boolean*          | Enables the part synchronization feature. False by default.                                                                                                                                |
 | `useInitialsBuilderLogic` | *boolean*          | Enables the usage of the client-side initials builder logic defined in the 3DB, instead of the default one. True by default.                                                               |
+| `initialsDebounce`        | *number*           | The debounce time to consider for every initials set request in ms (0 to not debounce). 275 by default.                                                                                    |
 
 ## Browser Support
 

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ if (ripe.isOAuthPending()) {
 | `usePrice`                | *boolean*          | Enables the fetch price feature every time a new part is set. True by default.                                                                                                             |
 | `useSync`                 | *boolean*          | Enables the part synchronization feature. False by default.                                                                                                                                |
 | `useInitialsBuilderLogic` | *boolean*          | Enables the usage of the client-side initials builder logic defined in the 3DB, instead of the default one. True by default.                                                               |
-| `initialsDebounce`        | *number*           | The debounce time to consider for every initials set request in ms (0 to not debounce). 275 by default.                                                                                    |
+| `initialsDebounce`        | *number*           | The debounce time (in milliseconds) for every initials set request in ms. 275 by default and 0 to disable.                                                                                    |
 
 ## Browser Support
 

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -889,23 +889,6 @@ ripe.Ripe.prototype.setInitials = async function(
 };
 
 /**
- * @ignore
- */
-ripe.Ripe.prototype._setInitialsDebounced = function(
-    initials,
-    engraving,
-    events = true,
-    override = false,
-    params = {}
-) {
-    if (this.setInitialsTimeout) clearTimeout(this.setInitialsTimeout);
-    this.setInitialsTimeout = setTimeout(() => {
-        const extraParams = { ...params, immediate: true };
-        this.setInitials(initials, engraving, events, override, extraParams);
-    }, this.initialsDebounce);
-};
-
-/**
  * Changes the initials of the model using an object as the input which
  * allows setting the initials for multiple groups at the same time.
  *
@@ -1001,22 +984,6 @@ ripe.Ripe.prototype.setInitialsExtra = async function(
 
     // returns the current instance (good for pipelining)
     return this;
-};
-
-/**
- * @ignore
- */
-ripe.Ripe.prototype._setInitialsExtraDebounced = function(
-    initialsExtra,
-    events = true,
-    override = false,
-    params = {}
-) {
-    if (this.setInitialsTimeout) clearTimeout(this.setInitialsTimeout);
-    this.setInitialsTimeout = setTimeout(() => {
-        const extraParams = { ...params, immediate: true };
-        this.setInitialsExtra(initialsExtra, events, override, extraParams);
-    }, this.initialsDebounce);
 };
 
 /**
@@ -1849,6 +1816,39 @@ ripe.Ripe.prototype._setParts = async function(update, events = true) {
         const part = update[index];
         await this._setPart(part[0], part[1], part[2], events);
     }
+};
+
+/**
+ * @ignore
+ */
+ripe.Ripe.prototype._setInitialsDebounced = function(
+    initials,
+    engraving,
+    events = true,
+    override = false,
+    params = {}
+) {
+    if (this.setInitialsTimeout) clearTimeout(this.setInitialsTimeout);
+    this.setInitialsTimeout = setTimeout(() => {
+        const extraParams = { ...params, immediate: true };
+        this.setInitials(initials, engraving, events, override, extraParams);
+    }, this.initialsDebounce);
+};
+
+/**
+ * @ignore
+ */
+ripe.Ripe.prototype._setInitialsExtraDebounced = function(
+    initialsExtra,
+    events = true,
+    override = false,
+    params = {}
+) {
+    if (this.setInitialsTimeout) clearTimeout(this.setInitialsTimeout);
+    this.setInitialsTimeout = setTimeout(() => {
+        const extraParams = { ...params, immediate: true };
+        this.setInitialsExtra(initialsExtra, events, override, extraParams);
+    }, this.initialsDebounce);
 };
 
 /**

--- a/test/js/base/ripe.js
+++ b/test/js/base/ripe.js
@@ -9,7 +9,10 @@ describe("Ripe", function() {
         it("should be able to get a simple structure", async () => {
             let result;
 
-            const instance = await new ripe.Ripe("swear", "vyner", { noBundles: true });
+            const instance = await new ripe.Ripe("swear", "vyner", {
+                noBundles: true,
+                initialsDebounce: 0
+            });
             await instance.isReady();
 
             result = await instance.getStructure();
@@ -188,7 +191,7 @@ describe("Ripe", function() {
 
     describe("#setInitials()", async function() {
         it("should be able to set initials", async () => {
-            const instance = await new ripe.Ripe({ noBundles: true });
+            const instance = await new ripe.Ripe({ noBundles: true, initialsDebounce: 0 });
             await instance.isReady();
 
             assert.strictEqual(instance.initials, "");


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-sdk/issues/357 |
| Decisions | - Use debouncer timer `initialsDebounce=275` for `setInitials` and `setInitialsExtra`. <br> - Adapt tests |

Notes:
* Frontend and backend debouncer strategies were tested and had similar response times.
* Doing a debouncer within `update` was the first approach but failed to be optimal as the event `initials_extra` triggers for an `update` with a null `params.reason` and it's not possible to adapt it without a huge refactor.
