### PR TITLE
#2075 YSL: Localized sanitization of initials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,6 +240,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Ability to override `name` and `meta` for attachments - [#282](https://github.com/ripe-tech/ripe-sdk/issues/282)
 * Added method to issue a create waybill command for a given order - [ripe-pulse/211](https://github.com/ripe-tech/ripe-pulse/issues/211)
 * Add `rejectOrderP` and `rejectOrder` methods - [ripe-pulse/#219](https://github.com/ripe-tech/ripe-pulse/issues/219)
+* Passing `locale` and `country` arguments in `ctx` when doing initials builder to allow localized sanitization of initials - [build-static/#2075](https://github.com/ripe-tech/builds-static/issues/2075) 
 
 ### Fixed
 

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -343,7 +343,9 @@ ripe.Image.prototype.update = async function(state, options = {}) {
             model: this.owner.model,
             version: this.owner.version,
             parts: this.owner.parts,
-            frame: this.frame
+            frame: this.frame,
+            locale: this.owner.locale,
+            country: this.owner.country
         };
         const initialsSpec = this.showInitials
             ? await this.initialsBuilder(


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/builds-static/issues/2075 |
| Decisions | - Passing `locale` and `country` arguments in `ctx` when doing initials builder to allow localized sanitization of initials |
