### PR TITLE
Added suport for invoicing info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Added support for `invoicingInfo` field - [ripe-utile-vue/#247](https://github.com/ripe-tech/ripe-util-vue/issues/247)
+* Added support for `invoicingInfo` field in `importOrder` - [ripe-util-vue/#247](https://github.com/ripe-tech/ripe-util-vue/issues/247)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Added support for `invoicingInfo` field - [ripe-utile-vue/#247](https://github.com/ripe-tech/ripe-util-vue/issues/247)
 
 ### Changed
 

--- a/src/js/api/order.js
+++ b/src/js/api/order.js
@@ -1883,6 +1883,7 @@ ripe.Ripe.prototype._importOrder = function(ffOrderId, options = {}) {
     const meta = options.meta === undefined ? null : options.meta;
     const description = options.description === undefined ? null : options.description;
     const shippingInfo = options.shippingInfo === undefined ? null : options.shippingInfo;
+    const invoicingInfo = options.invoicingInfo === undefined ? null : options.invoicingInfo;
     const notes = options.notes === undefined ? null : options.notes;
     const images = options.images === undefined ? null : options.images;
 
@@ -1910,6 +1911,7 @@ ripe.Ripe.prototype._importOrder = function(ffOrderId, options = {}) {
     if (images) contents.images = images;
     if (description) contents.description = description;
     if (shippingInfo) contents.shipping_info = shippingInfo;
+    if (invoicingInfo) contents.invoicing_info = invoicingInfo;
 
     const params = {
         ff_order_id: ffOrderId,


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-util-vue/issues/247 |
| Decisions | A new invoicing field will be added to `ripe-util-vue`, and in order to correctly import the information inside of `ripe-pulse`, that information needs to be given in a specific format. In order to ensure consistency with `shippingInfo`, the new `invoicingInfo` field is now parsed on the SDK side. |
| Screenshots | <img width="1310" alt="image" src="https://user-images.githubusercontent.com/22790704/156210606-592e0fe0-ae48-428f-a000-80601188ffbb.png"> This was taken on an order created using `ripe-util-vue`, with a linked `ripe-sdk` to the version of this commit. |
