### PR TITLE
#979: Methods `getSkusCsvP` and `countSkusP`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Added methods `getSkusCsvP` and `getSkusCsv` that return a CSV document containing SKUs - [ripe-white/#979](https://github.com/ripe-tech/ripe-white/issues/979)
+* Added methods `countSkusP` and `countSkus` that returns the number of SKUs - [ripe-white/#979](https://github.com/ripe-tech/ripe-white/issues/979)
 
 ### Changed
 

--- a/src/js/api/sku.js
+++ b/src/js/api/sku.js
@@ -79,7 +79,6 @@ ripe.Ripe.prototype.getSkusP = function(options) {
         auth: true
     });
     options = this._build(options);
-    console.log("OPTIONS", options);
     return this._cacheURL(options.url, options, callback);
 };
 

--- a/src/js/api/sku.js
+++ b/src/js/api/sku.js
@@ -55,6 +55,50 @@ ripe.Ripe.prototype.getSkusP = function(options) {
 };
 
 /**
+ * Gets the existing SKUs in a CSV file, according to the provided filtering
+ * strategy as normalized values.
+ *
+ * @param {Object} options An object of options to configure the request, such as:
+ * - 'filters[]' - List of filters that the query will use to, operators such as
+ * ('in', 'not_in', 'like', 'contains'), for instance (eg: 'id:eq:42') would filter by the id that equals to 42.
+ * - 'sort' - List of arguments to sort the results by and which direction
+ * to sort them in (eg: 'id:ascending') would sort by the id attribute in ascending order,
+ * while (eg: 'id:descending')] would do it in descending order.
+ * - 'skip' - The number of the first record to retrieve from the results.
+ * - 'limit' - The number of results to retrieve.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
+ */
+ ripe.Ripe.prototype.getSkusCsv = function(options, callback) {
+    callback = typeof options === "function" ? options : callback;
+    options = typeof options === "function" || options === undefined ? {} : options;
+    const url = `${this.url}skus.csv`;
+    options = Object.assign(options, {
+        url: url,
+        method: "GET",
+        auth: true
+    });
+    options = this._build(options);
+    console.log("OPTIONS", options);
+    return this._cacheURL(options.url, options, callback);
+};
+
+/**
+ * Gets the existing SKUs in a CSV file, according to the provided filtering
+ * strategy as normalized values.
+ *
+ * @param {Object} options An object of options to configure the request.
+ * @returns {Promise} A CSV file containing the SKUs result list.
+ */
+ripe.Ripe.prototype.getSkusCsvP = function(options) {
+    return new Promise((resolve, reject) => {
+        this.getSkusCsv(options, (result, isValid, request) => {
+            isValid ? resolve(result) : reject(new ripe.RemoteError(request, null, result));
+        });
+    });
+};
+
+/**
  * Creates a SKU on RIPE Core under the defined domain.
  *
  * @param {String} identifier The SKU identifier as a plain string.
@@ -276,6 +320,49 @@ ripe.Ripe.prototype.validateSku = function(id, options, callback) {
 ripe.Ripe.prototype.validateSkuP = function(id, options) {
     return new Promise((resolve, reject) => {
         this.validateSku(id, options, (result, isValid, request) => {
+            isValid ? resolve(result) : reject(new ripe.RemoteError(request, null, result));
+        });
+    });
+};
+
+/**
+ * Counts the existing SKUs, according to the provided filtering
+ * strategy as normalized values.
+ *
+ * @param {Object} options An object of options to configure the request, such as:
+ * - 'filters[]' - List of filters that the query will use to, operators such as
+ * ('in', 'not_in', 'like', 'contains'), for instance (eg: 'id:eq:42') would filter by the id that equals to 42.
+ * - 'sort' - List of arguments to sort the results by and which direction
+ * to sort them in (eg: 'id:ascending') would sort by the id attribute in ascending order,
+ * while (eg: 'id:descending')] would do it in descending order.
+ * - 'skip' - The number of the first record to retrieve from the results.
+ * - 'limit' - The number of results to retrieve.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
+ */
+ ripe.Ripe.prototype.countSkus = function(options, callback) {
+    callback = typeof options === "function" ? options : callback;
+    options = typeof options === "function" || options === undefined ? {} : options;
+    const url = `${this.url}skus/count`;
+    options = Object.assign(options, {
+        url: url,
+        method: "GET",
+        auth: true
+    });
+    options = this._build(options);
+    return this._cacheURL(options.url, options, callback);
+};
+
+/**
+ * Counts the existing SKUs, according to the provided filtering
+ * strategy as normalized values.
+ *
+ * @param {Object} options An object of options to configure the request.
+ * @returns {Promise} The SKUs result count.
+ */
+ripe.Ripe.prototype.countSkusP = function(options) {
+    return new Promise((resolve, reject) => {
+        this.countSkus(options, (result, isValid, request) => {
             isValid ? resolve(result) : reject(new ripe.RemoteError(request, null, result));
         });
     });

--- a/src/js/api/sku.js
+++ b/src/js/api/sku.js
@@ -59,8 +59,7 @@ ripe.Ripe.prototype.getSkusP = function(options) {
  * strategy as normalized values.
  *
  * @param {Object} options An object of options to configure the request, such as:
- * - 'filters[]' - List of filters that the query will use to, operators such as
- * ('in', 'not_in', 'like', 'contains'), for instance (eg: 'id:eq:42') would filter by the id that equals to 42.
+ * - 'filters[]' - List of filters that the query will use.
  * - 'sort' - List of arguments to sort the results by and which direction
  * to sort them in (eg: 'id:ascending') would sort by the id attribute in ascending order,
  * while (eg: 'id:descending')] would do it in descending order.
@@ -329,8 +328,7 @@ ripe.Ripe.prototype.validateSkuP = function(id, options) {
  * strategy as normalized values.
  *
  * @param {Object} options An object of options to configure the request, such as:
- * - 'filters[]' - List of filters that the query will use to, operators such as
- * ('in', 'not_in', 'like', 'contains'), for instance (eg: 'id:eq:42') would filter by the id that equals to 42.
+ * - 'filters[]' - List of filters that the query will use.
  * - 'sort' - List of arguments to sort the results by and which direction
  * to sort them in (eg: 'id:ascending') would sort by the id attribute in ascending order,
  * while (eg: 'id:descending')] would do it in descending order.


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/979 |
| Dependencies | https://github.com/ripe-tech/ripe-core/pull/4698 |
| Decisions | - Add methods `getSkusCsvP` and `countSkusP` that return a CSV containing SKU and the number of documents, respectively |
| Animated GIF | -- |
