### PR TITLE
fix: optional brand in payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Payload `brand` field for `importBulkOrder` optional - [ripe-pulse/#281](https://github.com/ripe-tech/ripe-pulse/issues/281)
 
 ## [2.23.0] - 2022-03-07
 

--- a/src/js/api/bulk-order.js
+++ b/src/js/api/bulk-order.js
@@ -535,7 +535,6 @@ ripe.Ripe.prototype._importBulkOrder = function(name, orders, options = {}) {
     const description = options.description === undefined ? null : options.description;
     const dataJ = {
         name: name,
-        brand: brand,
         orders: orders
     };
     if (brand) dataJ.brand = brand;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-pulse/issues/281 |
| Dependencies | -- |
| Decisions | Brand is optional so should not be used in the payload by default. |