### PR TITLE
#4703 Add size to rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,7 +259,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Support for multiple character escaping in `escape()`
 * Add method to retrieve the URL for an attachment
 * Support for retry in API requests when receiving authentication related errors (eg: 403)
-* Add size argument to resolveInvoiceRule - [ripe-core/#4703](https://github.com/ripe-tech/ripe-core/issues/4703)
+* Add size argument to `resolveInvoiceRule` - [ripe-core/#4703](https://github.com/ripe-tech/ripe-core/issues/4703)
 
 ## [2.2.1] - 2021-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,6 +259,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Support for multiple character escaping in `escape()`
 * Add method to retrieve the URL for an attachment
 * Support for retry in API requests when receiving authentication related errors (eg: 403)
+* Add size argument to resolveInvoiceRule - [ripe-core/#4703](https://github.com/ripe-tech/ripe-core/issues/4703)
 
 ## [2.2.1] - 2021-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,6 +260,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add method to retrieve the URL for an attachment
 * Support for retry in API requests when receiving authentication related errors (eg: 403)
 * Add size argument to `resolveInvoiceRule` - [ripe-core/#4703](https://github.com/ripe-tech/ripe-core/issues/4703)
+* Add missing `resolveTransportRule` and `resolveTransportRuleP` methods - [ripe-core/#4703](https://github.com/ripe-tech/ripe-core/issues/4703)
 
 ## [2.2.1] - 2021-06-13
 

--- a/src/js/api/invoice-rule.js
+++ b/src/js/api/invoice-rule.js
@@ -196,7 +196,7 @@ ripe.Ripe.prototype.deleteInvoiceRuleP = function(id, options) {
 };
 
 /**
- * Gets an existing invoice rule filtered by brand, model and country.
+ * Gets an existing invoice rule filtered by brand, model, country and size.
  *
  * @param {String} brand The invoice rule's brand.
  * @param {String} model The invoice rule's model.

--- a/src/js/api/invoice-rule.js
+++ b/src/js/api/invoice-rule.js
@@ -201,11 +201,12 @@ ripe.Ripe.prototype.deleteInvoiceRuleP = function(id, options) {
  * @param {String} brand The invoice rule's brand.
  * @param {String} model The invoice rule's model.
  * @param {String} country The invoice rule's country.
+ * @param {Number} size The invoice rule's size.
  * @param {Object} options An object of options to configure the request
  * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
  */
-ripe.Ripe.prototype.resolveInvoiceRule = function(brand, model, country, options, callback) {
+ripe.Ripe.prototype.resolveInvoiceRule = function(brand, model, country, size, options, callback) {
     callback = typeof options === "function" ? options : callback;
     options = typeof options === "function" || options === undefined ? {} : options;
     const url = `${this.url}invoice_rules/resolve`;
@@ -218,6 +219,9 @@ ripe.Ripe.prototype.resolveInvoiceRule = function(brand, model, country, options
     }
     if (country !== undefined && country !== null) {
         params.country = country;
+    }
+    if (size !== undefined && size !== null) {
+        params.size = size;
     }
     options = Object.assign(options, {
         url: url,
@@ -235,13 +239,21 @@ ripe.Ripe.prototype.resolveInvoiceRule = function(brand, model, country, options
  * @param {String} brand The invoice rule's brand.
  * @param {String} model The invoice rule's model.
  * @param {String} country The invoice rule's country.
+ * @param {Number} size The invoice rule's size.
  * @param {Object} options An object of options to configure the request.
  * @returns {Promise} The invoice rule requested by brand, model and country.
  */
-ripe.Ripe.prototype.resolveInvoiceRuleP = function(brand, model, country, options) {
+ripe.Ripe.prototype.resolveInvoiceRuleP = function(brand, model, country, size, options) {
     return new Promise((resolve, reject) => {
-        this.resolveInvoiceRule(brand, model, country, options, (result, isValid, request) => {
-            isValid ? resolve(result) : reject(new ripe.RemoteError(request, null, result));
-        });
+        this.resolveInvoiceRule(
+            brand,
+            model,
+            country,
+            size,
+            options,
+            (result, isValid, request) => {
+                isValid ? resolve(result) : reject(new ripe.RemoteError(request, null, result));
+            }
+        );
     });
 };

--- a/src/js/api/transport-rule.js
+++ b/src/js/api/transport-rule.js
@@ -246,7 +246,7 @@ ripe.Ripe.prototype.resolveTransportRule = function(
 };
 
 /**
- * Gets an existing transport rule filtered by brand, model and country.
+ * Gets an existing transport rule filtered by brand, model, country, factory and size.
  *
  * @param {String} brand The transport rule's brand.
  * @param {String} model The transport rule's model.

--- a/src/js/api/transport-rule.js
+++ b/src/js/api/transport-rule.js
@@ -194,3 +194,87 @@ ripe.Ripe.prototype.deleteTransportRuleP = function(id, options) {
         });
     });
 };
+
+/**
+ * Gets an existing transport rule filtered by brand, model and country.
+ *
+ * @param {String} brand The transport rule's brand.
+ * @param {String} model The transport rule's model.
+ * @param {String} country The transport rule's country.
+ * @param {String} factory The transport rule's factory.
+ * @param {Number} size The transport rule's size.
+ * @param {Object} options An object of options to configure the request
+ * @param {Function} callback Function with the result of the request.
+ * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
+ */
+ripe.Ripe.prototype.resolveTransportRule = function(
+    brand,
+    model,
+    country,
+    factory,
+    size,
+    options,
+    callback
+) {
+    callback = typeof options === "function" ? options : callback;
+    options = typeof options === "function" || options === undefined ? {} : options;
+    const url = `${this.url}transport_rules/resolve`;
+    const params = {};
+    if (brand !== undefined && brand !== null) {
+        params.brand = brand;
+    }
+    if (model !== undefined && model !== null) {
+        params.model = model;
+    }
+    if (country !== undefined && country !== null) {
+        params.country = country;
+    }
+    if (factory !== undefined && factory !== null) {
+        params.factory = factory;
+    }
+    if (size !== undefined && size !== null) {
+        params.size = size;
+    }
+    options = Object.assign(options, {
+        url: url,
+        method: "GET",
+        params: params,
+        auth: true
+    });
+    options = this._build(options);
+    return this._cacheURL(options.url, options, callback);
+};
+
+/**
+ * Gets an existing transport rule filtered by brand, model and country.
+ *
+ * @param {String} brand The transport rule's brand.
+ * @param {String} model The transport rule's model.
+ * @param {String} country The transport rule's country.
+ * @param {String} factory The transport rule's factory.
+ * @param {Number} size The transport rule's size.
+ * @param {Object} options An object of options to configure the request.
+ * @returns {Promise} The transport rule requested by brand, model and country.
+ */
+ripe.Ripe.prototype.resolveTransportRuleP = function(
+    brand,
+    model,
+    country,
+    factory,
+    size,
+    options
+) {
+    return new Promise((resolve, reject) => {
+        this.resolveTransportRule(
+            brand,
+            model,
+            country,
+            factory,
+            size,
+            options,
+            (result, isValid, request) => {
+                isValid ? resolve(result) : reject(new ripe.RemoteError(request, null, result));
+            }
+        );
+    });
+};

--- a/src/js/api/transport-rule.js
+++ b/src/js/api/transport-rule.js
@@ -196,7 +196,7 @@ ripe.Ripe.prototype.deleteTransportRuleP = function(id, options) {
 };
 
 /**
- * Gets an existing transport rule filtered by brand, model and country.
+ * Gets an existing transport rule filtered by brand, model, country, factory and size.
  *
  * @param {String} brand The transport rule's brand.
  * @param {String} model The transport rule's model.


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-core/issues/4703 |
| Dependencies | https://github.com/ripe-tech/ripe-core/pull/4707 |
| Decisions | - Adapt ripe-sdk methods to new size dimensions in rules. <br> - Add missing resolveTransportRule and resolveTransportRuleP methods.  |
