### PR TITLE
#317: filter and fetch justifications by code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Always loading default bundle locales for scales and sizes
+* Better `getJustifications` resolving logic for context, code and full code allowing better searching - [ripe-pulse/#317](https://github.com/ripe-tech/ripe-pulse/issues/317)
 
 ### Fixed
 

--- a/src/js/api/justification.js
+++ b/src/js/api/justification.js
@@ -24,7 +24,6 @@ if (
  * - 'skip' - The number of the first record to retrieve from the results.
  * - 'limit' - The number of results to retrieve.
  * @param {Function} callback Function with the result of the request.
- * @param {Function} callback Function with the result of the request.
  * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
  */
 ripe.Ripe.prototype.getJustifications = function(options, callback) {
@@ -107,6 +106,21 @@ ripe.Ripe.prototype.getJustificationsByContextP = function(context, options) {
     });
 };
 
+/**
+ * Gets the existing justifications, according to the provided filtering
+ * strategy as normalized values.
+ *
+ * Attempts to resolve context, code and full code based on what is given.
+ * Adds those parameters to the filters given.
+ *
+ * If the 'other' code is used, it returns the adhoc text message without
+ * requesting a justification from RIPE Core.
+ *
+ * @param {Object} options An object of options to configure the request.
+ * @param {Function} callback Function with the result of the request.
+ * @param {String} other The 'other' prefix code.
+ * @returns {XMLHttpRequest} The XMLHttpRequest instance of the API request.
+ */
 ripe.Ripe.prototype._getJustifications = function(options, callback, other = "other;") {
     // resolve context, code and full code based on available
     // information, using smarter filters
@@ -135,6 +149,13 @@ ripe.Ripe.prototype._getJustifications = function(options, callback, other = "ot
     return this._cacheURL(options.url, options, callback);
 };
 
+/**
+ * Attempts to resolve context, code and full code based on what is given.
+ * A full code is equivalent to 'context:code'.
+ *
+ * @param {Object} options An object of options that may include context, code or a full code.
+ * @returns {Object} The params to be added as filters like context, code and full code.
+ */
 ripe.Ripe.prototype._resolveJustificationParams = function(options) {
     const params = {};
     if (options.codeFull) {

--- a/src/js/api/justification.js
+++ b/src/js/api/justification.js
@@ -110,31 +110,32 @@ ripe.Ripe.prototype.getJustificationsByContextP = function(context, options) {
 ripe.Ripe.prototype._getJustifications = function(options, callback, other = "other;") {
     // resolve context, code and full code based on available
     // information, using smarter filters
-    const filters = this._resolveJustificationFilters(options);
+    const params = this._resolveJustificationParams(options);
 
     // exits if the 'other' context is used which works
     // as an escape hatch and does not need to be looked up
-    if (filters.codeFull && filters.codeFull.includes(other)) {
-        const index = filters.codeFull.indexOf(other);
-        return {
+    if (params.codeFull && params.codeFull.includes(other)) {
+        const index = params.codeFull.indexOf(other);
+        const justification = {
             context: "other",
-            code_full: filters.codeFull,
-            text: filters.codeFull.slice(index + other.length)
+            code_full: params.codeFull,
+            text: params.codeFull.slice(index + other.length)
         };
+        return callback([justification], true, null);
     }
 
     // builds the appropriate filters for context, code
     // and full code, used to fetch the justification
     options.params = options.params !== undefined ? options.params : {};
     options.params.filters = options.params.filters !== undefined ? options.params.filters : [];
-    if (filters.context) options.params.filters.push(`context:likei:${filters.context}`);
-    if (filters.code) options.params.filters.push(`code:likei:${filters.code}`);
-    if (filters.codeFull) options.params.filters.push(`code_full:likei:${filters.codeFull}`);
+    if (params.context) options.params.filters.push(`context:likei:${params.context}`);
+    if (params.code) options.params.filters.push(`code:likei:${params.code}`);
+    if (params.codeFull) options.params.filters.push(`code_full:likei:${params.codeFull}`);
 
     return this._cacheURL(options.url, options, callback);
 };
 
-ripe.Ripe.prototype._resolveJustificationFilters = function(options) {
+ripe.Ripe.prototype._resolveJustificationParams = function(options) {
     const params = {};
     if (options.codeFull) {
         const [context, code] = options.codeFull.split(":");


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-pulse/issues/317 |
| Dependencies | -- |
| Decisions | Moving the default logic (of resolving `context:code` or just `code_full`) to the SDK. Also hides away the logic of the `other;` "escape hatch". This logic would have to be repeated in clients like RIPE Robin or RIPE Pulse (and future ones). |

![image](https://user-images.githubusercontent.com/16060539/159314547-9ef7238e-b870-46c5-9f90-1c13c55c5994.png)

![image](https://user-images.githubusercontent.com/16060539/159314052-05138126-f66b-419d-b547-2a0d4b7f8dec.png)
