### PR TITLE
#966: Image support for external image providers/frame validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add methods `getVideoP` and `getVideoThumbnailP` that return the video and video thumbnail for a given model and its customization - [ripe-white/#996](https://github.com/ripe-tech/ripe-white/issues/996)
 * Add methods `_getVideoURL` and `_getVideoThumbnailURL` that return the URL of a video and video thumbnail, respectively, for a given model and its customization - [ripe-white/#996](https://github.com/ripe-tech/ripe-white/issues/996)
 * General order chat methods - [ripe-core/#4702](https://github.com/ripe-tech/ripe-core/issues/4702)
+* Support for external image URL providers and frame validators for image - [ripe-white/#996](https://github.com/ripe-tech/ripe-white/issues/996)
+* Validator function `hasVideo` that verifies if a video exists in the build spec - [ripe-white/#996](https://github.com/ripe-tech/ripe-white/issues/996)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * General order chat methods - [ripe-core/#4702](https://github.com/ripe-tech/ripe-core/issues/4702)
 * Support for external image URL providers and frame validators for image - [ripe-white/#996](https://github.com/ripe-tech/ripe-white/issues/996)
 * Validator function `hasVideo` that verifies if a video exists in the build spec - [ripe-white/#996](https://github.com/ripe-tech/ripe-white/issues/996)
+* New image bind method `bindVideoThumbnail` specific for binding to an image tag the video thumbnail image - [ripe-white/#996](https://github.com/ripe-tech/ripe-white/issues/996)
 
 ### Changed
 

--- a/src/js/base/logic.js
+++ b/src/js/base/logic.js
@@ -263,6 +263,7 @@ ripe.Ripe.prototype.hasVideo = function(name) {
     if (!this.loadedConfig) return true;
     if (!name) return true;
 
+    if (!this.loadedConfig.videos_m) return false;
     return Boolean(this.loadedConfig.videos_m[name]);
 };
 

--- a/src/js/base/logic.js
+++ b/src/js/base/logic.js
@@ -251,7 +251,7 @@ ripe.Ripe.prototype.hasFrame = function(frame) {
  * provided video name available in spec.
  *
  * Notice that this call does not assure that a video showing is possible
- * it only determines that according to model's spec it should be
+ * it only determines if according to the model's spec it should be
  * possible to get such a video.
  *
  * @param {String} frame The name of the video to determine if it is

--- a/src/js/base/logic.js
+++ b/src/js/base/logic.js
@@ -264,7 +264,9 @@ ripe.Ripe.prototype.hasVideo = function(name) {
     if (!name) return true;
 
     if (!this.loadedConfig.videos_m) return false;
-    return Boolean(this.loadedConfig.videos_m[name]);
+    if (!this.loadedConfig.videos_m[name]) return false;
+
+    return true;
 };
 
 /**

--- a/src/js/base/logic.js
+++ b/src/js/base/logic.js
@@ -247,6 +247,26 @@ ripe.Ripe.prototype.hasFrame = function(frame) {
 };
 
 /**
+ * Determines if the model currently loaded (in case there's one) has the
+ * provided video name available in spec.
+ *
+ * Notice that this call does not assure that a video showing is possible
+ * it only determines that according to model's spec it should be
+ * possible to get such a video.
+ *
+ * @param {String} frame The name of the video to determine if it is
+ * possible to show that video.
+ * @returns {Boolean} If it's possible to show the video for the
+ * currently loaded model.
+ */
+ripe.Ripe.prototype.hasVideo = function(name) {
+    if (!this.loadedConfig) return true;
+    if (!name) return true;
+
+    return Boolean(this.loadedConfig.videos_m[name]);
+};
+
+/**
  * Localizes the given string value taking into account the current
  * brand and model context so that proper prefixes are taking into
  * account for proper build locale usage.

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -1187,6 +1187,27 @@ ripe.Ripe.prototype.bindImage = function(element, options = {}) {
 };
 
 /**
+ * Binds a video thumbnail Image to this Ripe instance.
+ *
+ * @param {Image} element The Image to be used by the Ripe instance.
+ * @param {Object} options An Object with options to configure the Image instance.
+ * @returns {Image} The Image instance created.
+ */
+ripe.Ripe.prototype.bindVideoThumbnail = function(element, options = {}) {
+    options = Object.assign(
+        {},
+        {
+            imageUrlProvider: this._getVideoThumbnailURL.bind(this),
+            frameValidator: this.hasVideo.bind(this),
+            doubleBuffering: false
+        },
+        options
+    );
+    const image = new ripe.Image(this, element, options);
+    return this.bindInteractable(image);
+};
+
+/**
  * Binds an Configurator to this Ripe instance.
  *
  * @param {Configurator} element The Configurator to be used by the Ripe instance.


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/996 |
| Dependencies | https://github.com/ripe-tech/ripe-core/pull/4710 |
| Decisions | - Added support in `image.js` for external image URL providers and frame validators. With this, the thumbnail component just needs to make `bindImage´ with the correct provider and SDK deals with the rest (update parts, change frame, etc)  |
| Animated GIF | Below |

https://user-images.githubusercontent.com/25725586/159502592-c9097962-8f4b-4efd-9388-129398494e2a.mp4

https://user-images.githubusercontent.com/25725586/159502626-bcfff4e5-2d40-4fac-91a9-e8970cf8ccfc.mp4
