### PR TITLE
YSL: Add `remoteInitialsBuilderLogic` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Added `remoteInitialsBuilderLogic` option to specify if the initials builder logic should run on server-side.  
+* Added `noAwaitLayout` option - current updates don't wait for the previous ones to be complete.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Added method `resolveJustification` to find the matching justificaton given context and code or full code - [ripe-pulse/#317](https://github.com/ripe-tech/ripe-pulse/issues/317)
-* Added `remoteInitialsBuilderLogic` option to specify if the initials builder logic should run on server-side.  
+* Added method `resolveJustification` to find the matching justification given context and code or full code - [ripe-pulse/#317](https://github.com/ripe-tech/ripe-pulse/issues/317)
+* Added `composeLogic` option to specify if the (initials builder) logic should run on server-side.  
 * Added `noAwaitLayout` option so that current updates don't wait for the previous ones to be complete.
 
 ### Changed
@@ -300,7 +300,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Ability to override `name` and `meta` for attachments - [#282](https://github.com/ripe-tech/ripe-sdk/issues/282)
 * Added method to issue a create waybill command for a given order - [ripe-pulse/211](https://github.com/ripe-tech/ripe-pulse/issues/211)
 * Add `rejectOrderP` and `rejectOrder` methods - [ripe-pulse/#219](https://github.com/ripe-tech/ripe-pulse/issues/219)
-* Passing `locale` and `country` arguments in `ctx` when doing initials builder to allow localized sanitization of initials - [build-static/#2075](https://github.com/ripe-tech/builds-static/issues/2075) 
+* Passing `locale` and `country` arguments in `ctx` when doing initials builder to allow localized sanitization of initials - [build-static/#2075](https://github.com/ripe-tech/builds-static/issues/2075)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Added `remoteInitialsBuilderLogic` option to specify if the initials builder logic should run on server-side.  
-* Added `noAwaitLayout` option - current updates don't wait for the previous ones to be complete.
+* Added `noAwaitLayout` option so that current updates don't wait for the previous ones to be complete.
 
 ### Changed
 

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -683,16 +683,13 @@ ripe.Ripe.prototype.setOptions = function(options = {}) {
     this.usePrice = this.options.usePrice === undefined ? !this.noPrice : this.options.usePrice;
     this.noDiag = this.options.noDiag === undefined ? false : this.options.noDiag;
     this.useDiag = this.options.useDiag === undefined ? !this.noDiag : this.options.useDiag;
+    this.noAwaitLayout =
+        this.options.noAwaitLayout === undefined ? false : this.options.noAwaitLayout;
     this.useInitialsBuilderLogic =
         this.options.useInitialsBuilderLogic === undefined
             ? true
             : this.options.useInitialsBuilderLogic;
-    this.remoteInitialsBuilderLogic =
-        this.options.remoteInitialsBuilderLogic === undefined
-            ? false
-            : this.options.remoteInitialsBuilderLogic;
-    this.noAwaitLayout =
-        this.options.noAwaitLayout === undefined ? false : this.options.noAwaitLayout;
+    this.composeLogic = this.options.composeLogic === undefined ? false : this.options.composeLogic;
 
     // in case the requested format is the "dynamic" lossless one
     // tries to find the best lossless image format taking into account

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -692,9 +692,7 @@ ripe.Ripe.prototype.setOptions = function(options = {}) {
             ? false
             : this.options.remoteInitialsBuilderLogic;
     this.noAwaitLayout =
-        this.options.noAwaitLayout === undefined
-            ? false
-            : this.options.noAwaitLayout;
+        this.options.noAwaitLayout === undefined ? false : this.options.noAwaitLayout;
 
     // in case the requested format is the "dynamic" lossless one
     // tries to find the best lossless image format taking into account

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -1398,7 +1398,9 @@ ripe.Ripe.prototype.update = async function(state = null, options = {}, children
     // so that we can safely run the new update promise after all the other
     // previously registered ones are "flushed", after te update the promise
     // reference is forced to null to indicate that no more promises exist
-    if (this.updatePromise && !this.noAwaitLayout) await this.updatePromise;
+    if (this.updatePromise && (!options.noAwaitLayout || !this.noAwaitLayout)) {
+        await this.updatePromise;
+    }
     this.updatePromise = null;
 
     // in case the current update operation is no longer the latest one then

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -687,6 +687,10 @@ ripe.Ripe.prototype.setOptions = function(options = {}) {
         this.options.useInitialsBuilderLogic === undefined
             ? true
             : this.options.useInitialsBuilderLogic;
+    this.remoteInitialsBuilderLogic =
+        this.options.remoteInitialsBuilderLogic === undefined
+            ? false
+            : this.options.remoteInitialsBuilderLogic;
 
     // in case the requested format is the "dynamic" lossless one
     // tries to find the best lossless image format taking into account
@@ -1371,7 +1375,7 @@ ripe.Ripe.prototype.update = async function(state = null, options = {}, children
     // so that we can safely run the new update promise after all the other
     // previously registered ones are "flushed", after te update the promise
     // reference is forced to null to indicate that no more promises exist
-    if (this.updatePromise) await this.updatePromise;
+    if (this.updatePromise && !this.remoteInitialsBuilderLogic) await this.updatePromise;
     this.updatePromise = null;
 
     // in case the current update operation is no longer the latest one then
@@ -1380,7 +1384,7 @@ ripe.Ripe.prototype.update = async function(state = null, options = {}, children
 
     try {
         this.updatePromise = _update();
-        if (options.noAwaitLayout) return true;
+        if (options.noAwaitLayout || this.remoteInitialsBuilderLogic) return true;
         const result = await this.updatePromise;
         return result;
     } finally {

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -691,6 +691,10 @@ ripe.Ripe.prototype.setOptions = function(options = {}) {
         this.options.remoteInitialsBuilderLogic === undefined
             ? false
             : this.options.remoteInitialsBuilderLogic;
+    this.noAwaitLayout =
+        this.options.noAwaitLayout === undefined
+            ? false
+            : this.options.noAwaitLayout;
 
     // in case the requested format is the "dynamic" lossless one
     // tries to find the best lossless image format taking into account
@@ -1396,7 +1400,7 @@ ripe.Ripe.prototype.update = async function(state = null, options = {}, children
     // so that we can safely run the new update promise after all the other
     // previously registered ones are "flushed", after te update the promise
     // reference is forced to null to indicate that no more promises exist
-    if (this.updatePromise && !this.remoteInitialsBuilderLogic) await this.updatePromise;
+    if (this.updatePromise && !this.noAwaitLayout) await this.updatePromise;
     this.updatePromise = null;
 
     // in case the current update operation is no longer the latest one then
@@ -1405,7 +1409,7 @@ ripe.Ripe.prototype.update = async function(state = null, options = {}, children
 
     try {
         this.updatePromise = _update();
-        if (options.noAwaitLayout || this.remoteInitialsBuilderLogic) return true;
+        if (options.noAwaitLayout || this.noAwaitLayout) return true;
         const result = await this.updatePromise;
         return result;
     } finally {

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -105,6 +105,8 @@ ripe.Image.prototype.init = function() {
     this.showInitials = this.options.showInitials || false;
     this.remoteInitialsBuilderLogic =
         this.options.remoteInitialsBuilderLogic || this.owner.remoteInitialsBuilderLogic || false;
+    this.noAwaitLayout =
+        this.options.noAwaitLayout || this.owner.noAwaitLayout || false;
     this.initialsGroup = this.options.initialsGroup || null;
     this.initialsContext = this.options.initialsContext || null;
     this.getInitialsContext = this.options.getInitialsContext || null;
@@ -547,7 +549,7 @@ ripe.Image.prototype.update = async function(state, options = {}) {
     // for the update promise to be finished (in case an update is
     // currently running)
     await this.cancel();
-    if (this._updatePromise && !this.remoteInitialsBuilderLogic) await this._updatePromise;
+    if (this._updatePromise && !this.noAwaitLayout) await this._updatePromise;
 
     this._updatePromise = _update();
     try {
@@ -638,6 +640,17 @@ ripe.Image.prototype.setShowInitials = async function(showInitials) {
  */
 ripe.Image.prototype.setRemoteInitialsBuilderLogic = async function(remoteInitialsBuilderLogic) {
     this.remoteInitialsBuilderLogic = remoteInitialsBuilderLogic;
+    await this.update();
+};
+
+/**
+ * Updates the Image's `noAwaitLayout` flag that indicates if the
+ * current update should wait the completion of the previous one.
+ *
+ * @param {String} showInitials If the image should display initials.
+ */
+ripe.Image.prototype.setNoAwaitLayout = async function(noAwaitLayout) {
+    this.noAwaitLayout = noAwaitLayout;
     await this.update();
 };
 

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -103,15 +103,14 @@ ripe.Image.prototype.init = function() {
     this.offsets = this.options.offsets || null;
     this.curve = this.options.curve || null;
     this.showInitials = this.options.showInitials || false;
-    this.remoteInitialsBuilderLogic =
-        this.options.remoteInitialsBuilderLogic || this.owner.remoteInitialsBuilderLogic || false;
-    this.noAwaitLayout = this.options.noAwaitLayout || this.owner.noAwaitLayout || false;
     this.initialsGroup = this.options.initialsGroup || null;
     this.initialsContext = this.options.initialsContext || null;
     this.getInitialsContext = this.options.getInitialsContext || null;
     this.initialsBuilder = this.options.initialsBuilder || this.owner.initialsBuilder;
     this.doubleBuffering =
         this.options.doubleBuffering === undefined ? true : this.options.doubleBuffering;
+    this.noAwaitLayout = this.options.noAwaitLayout || this.owner.noAwaitLayout || false;
+    this.composeLogic = this.options.composeLogic || this.owner.composeLogic || false;
     this.imageUrlProvider =
         this.options.imageUrlProvider === undefined
             ? (...args) => this.owner._getImageURL(...args)
@@ -340,10 +339,7 @@ ripe.Image.prototype.update = async function(state, options = {}) {
         const offsets = this.element.dataset.offsets || this.offsets;
         const curve = this.element.dataset.curve || this.curve;
         const doubleBuffering = this.element.dataset.doubleBuffering || this.doubleBuffering;
-        const remoteInitialsBuilderLogic =
-            this.element.dataset.remoteInitialsBuilderLogic ||
-            this.remoteInitialsBuilderLogic ||
-            undefined;
+        const composeLogic = this.element.dataset.composeLogic || this.composeLogic || undefined;
 
         // in case the state is defined tries to gather the appropriate
         // sate options for both initials and engraving taking into
@@ -369,10 +365,10 @@ ripe.Image.prototype.update = async function(state, options = {}) {
 
         let initialsSpec = {};
 
-        // in case remote initials builder logic has been requested then
+        // in case the compose (initials builder) logic has been requested then
         // a simple initials spec is set with only the initials value present
         // the remainder of the logic will be executed on the server-side
-        if (remoteInitialsBuilderLogic) {
+        if (composeLogic) {
             initialsSpec = { initials: this.initials };
         }
         // otherwise "prepares" the execution of the business logic allowing
@@ -490,7 +486,7 @@ ripe.Image.prototype.update = async function(state, options = {}) {
             shadowColor: shadowColor,
             shadowOffset: shadowOffset,
             offsets: offsets,
-            logic: remoteInitialsBuilderLogic,
+            logic: composeLogic,
             curve: curve
         });
 
@@ -641,15 +637,15 @@ ripe.Image.prototype.setShowInitials = async function(showInitials) {
 };
 
 /**
- * Updates the Image's `setRemoteInitialsBuilderLogic` flag that indicates
+ * Updates the Image's `setComposeLogic` flag that indicates
  * if the initials builder logic should only run on the server side.
  *
- * @param {String} remoteInitialsBuilderLogic If the remote initials builder
- * logic should be executed or not, in case this value is defined the local
+ * @param {String} composeLogic If the compose (initials builder) logic
+ * should be executed or not, in case this value is defined the local
  * initials builder logic should not be executed.
  */
-ripe.Image.prototype.setRemoteInitialsBuilderLogic = async function(remoteInitialsBuilderLogic) {
-    this.remoteInitialsBuilderLogic = remoteInitialsBuilderLogic;
+ripe.Image.prototype.setComposeLogic = async function(composeLogic) {
+    this.composeLogic = composeLogic;
     await this.update();
 };
 

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -104,7 +104,7 @@ ripe.Image.prototype.init = function() {
     this.curve = this.options.curve || null;
     this.showInitials = this.options.showInitials || false;
     this.remoteInitialsBuilderLogic =
-        this.options.remoteInitialsBuilderLogic || this.owner.remoteInitialsBuilderLogic || null;
+        this.options.remoteInitialsBuilderLogic || this.owner.remoteInitialsBuilderLogic || false;
     this.initialsGroup = this.options.initialsGroup || null;
     this.initialsContext = this.options.initialsContext || null;
     this.getInitialsContext = this.options.getInitialsContext || null;
@@ -328,7 +328,9 @@ ripe.Image.prototype.update = async function(state, options = {}) {
         const curve = this.element.dataset.curve || this.curve;
         const doubleBuffering = this.element.dataset.doubleBuffering || this.doubleBuffering;
         const remoteInitialsBuilderLogic =
-            this.element.dataset.remoteInitialsBuilderLogic || this.remoteInitialsBuilderLogic;
+            this.element.dataset.remoteInitialsBuilderLogic ||
+            this.remoteInitialsBuilderLogic ||
+            undefined;
 
         // in case the state is defined tries to gather the appropriate
         // sate options for both initials and engraving taking into

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -623,8 +623,8 @@ ripe.Image.prototype.setShowInitials = async function(showInitials) {
  *
  * @param {String} showInitials If the image should display initials.
  */
-ripe.Image.prototype.setRemoteInitialsLogic = async function(remoteInitialsLogic) {
-    this.remoteInitialsLogic = remoteInitialsLogic;
+ripe.Image.prototype.setRemoteInitialsBuilderLogic = async function(remoteInitialsBuilderLogic) {
+    this.remoteInitialsBuilderLogic = remoteInitialsBuilderLogic;
     await this.update();
 };
 

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -328,7 +328,9 @@ ripe.Image.prototype.update = async function(state, options = {}) {
         const curve = this.element.dataset.curve || this.curve;
         const doubleBuffering = this.element.dataset.doubleBuffering || this.doubleBuffering;
         const remoteInitialsBuilderLogic =
-            this.element.dataset.remoteInitialsBuilderLogic || this.remoteInitialsBuilderLogic;
+            this.element.dataset.remoteInitialsBuilderLogic ||
+            this.remoteInitialsBuilderLogic ||
+            undefined;
 
         // in case the state is defined tries to gather the appropriate
         // sate options for both initials and engraving taking into

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -633,8 +633,8 @@ ripe.Image.prototype.setShowInitials = async function(showInitials) {
 };
 
 /**
- * Updates the Image's `showInitials` flag that indicates
- * if the initials should be display in the image.
+ * Updates the Image's `setRemoteInitialsBuilderLogic` flag that indicates
+ * if the initials builder logic should only run on the server side.
  *
  * @param {String} showInitials If the image should display initials.
  */

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -104,7 +104,7 @@ ripe.Image.prototype.init = function() {
     this.curve = this.options.curve || null;
     this.showInitials = this.options.showInitials || false;
     this.remoteInitialsBuilderLogic =
-        this.options.remoteInitialsBuilderLogic || this.owner.remoteInitialsBuilderLogic || false;
+        this.options.remoteInitialsBuilderLogic || this.owner.remoteInitialsBuilderLogic || null;
     this.initialsGroup = this.options.initialsGroup || null;
     this.initialsContext = this.options.initialsContext || null;
     this.getInitialsContext = this.options.getInitialsContext || null;
@@ -328,9 +328,7 @@ ripe.Image.prototype.update = async function(state, options = {}) {
         const curve = this.element.dataset.curve || this.curve;
         const doubleBuffering = this.element.dataset.doubleBuffering || this.doubleBuffering;
         const remoteInitialsBuilderLogic =
-            this.element.dataset.remoteInitialsBuilderLogic ||
-            this.remoteInitialsBuilderLogic ||
-            undefined;
+            this.element.dataset.remoteInitialsBuilderLogic || this.remoteInitialsBuilderLogic;
 
         // in case the state is defined tries to gather the appropriate
         // sate options for both initials and engraving taking into

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -105,8 +105,7 @@ ripe.Image.prototype.init = function() {
     this.showInitials = this.options.showInitials || false;
     this.remoteInitialsBuilderLogic =
         this.options.remoteInitialsBuilderLogic || this.owner.remoteInitialsBuilderLogic || false;
-    this.noAwaitLayout =
-        this.options.noAwaitLayout || this.owner.noAwaitLayout || false;
+    this.noAwaitLayout = this.options.noAwaitLayout || this.owner.noAwaitLayout || false;
     this.initialsGroup = this.options.initialsGroup || null;
     this.initialsContext = this.options.initialsContext || null;
     this.getInitialsContext = this.options.getInitialsContext || null;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | - Add `remoteInitialsBuilderLogic` and `noAwaitLayout` options. <br> - Adapt to not use initials builder in the client side and the cancellation logic to allow for faster response times. |

