### PR TITLE
fix: no faces in dimension spec in `getDimension`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Support no `faces` in a dimension from spec in ´getDimension`
 
 ## [2.25.0] - 2022-03-24
 

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -1649,6 +1649,7 @@ ripe.Ripe.prototype.getDimension = function(name = "$base", face = null) {
     }
 
     if (!face) return dimensionSpec;
+    if (!dimensionSpec.faces) return dimensionSpec;
 
     return dimensionSpec.faces[face] ? dimensionSpec.faces[face] : dimensionSpec;
 };


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Happening in https://ripe-white-now.platforme.com/?brand=unspun&model=cozy_wide ![image](https://user-images.githubusercontent.com/25725586/160116609-fe45ba20-191a-4de2-b765-98dea5c99606.png) |
| Dependencies | -- |
| Decisions | - Unspun build does not have faces in the dimension in spec, added conditional for that |
| Animated GIF | -- |
