### PR TITLE
#380 get order image url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Support for external image URL providers and frame validators for image - [ripe-white/#996](https://github.com/ripe-tech/ripe-white/issues/996)
 * Validator function `hasVideo` that verifies if a video exists in the build spec - [ripe-white/#996](https://github.com/ripe-tech/ripe-white/issues/996)
 * New image bind method `bindVideoThumbnail` specific for binding to an image tag the video thumbnail image - [ripe-white/#996](https://github.com/ripe-tech/ripe-white/issues/996)
+* Add method `_getOrderImageURL` - [#380](https://github.com/ripe-tech/ripe-sdk/issues/380)
 
 ### Changed
 

--- a/src/js/api/order.js
+++ b/src/js/api/order.js
@@ -2153,7 +2153,7 @@ ripe.Ripe.prototype._getOrderReportPNGURL = function(number, key, options) {
 /**
  * @ignore
  */
- ripe.Ripe.prototype._getOrderImageURL = function(number, key, options) {
+ripe.Ripe.prototype._getOrderImageURL = function(number, key, options) {
     options = options === undefined ? {} : options;
     const url = `${this.url}orders/${number}/image`;
     const params = options.params || {};

--- a/src/js/api/order.js
+++ b/src/js/api/order.js
@@ -2156,9 +2156,11 @@ ripe.Ripe.prototype._getOrderReportPNGURL = function(number, key, options) {
  ripe.Ripe.prototype._getOrderImageURL = function(number, key, options) {
     options = options === undefined ? {} : options;
     const url = `${this.url}orders/${number}/image`;
+    const params = options.params || {};
+    params.key = key;
     options = Object.assign(options, {
         url: url,
-        params: { key: key }
+        params: params
     });
     return options.url + "?" + this._buildQuery(options.params);
 };

--- a/src/js/api/order.js
+++ b/src/js/api/order.js
@@ -2152,6 +2152,19 @@ ripe.Ripe.prototype._getOrderReportPNGURL = function(number, key, options) {
 
 /**
  * @ignore
+ */
+ ripe.Ripe.prototype._getOrderImageURL = function(number, key, options) {
+    options = options === undefined ? {} : options;
+    const url = `${this.url}orders/${number}/image`;
+    options = Object.assign(options, {
+        url: url,
+        params: { key: key }
+    });
+    return options.url + "?" + this._buildQuery(options.params);
+};
+
+/**
+ * @ignore
  * @see {link https://docs.platforme.com/#order-endpoints-import}
  */
 ripe.Ripe.prototype._importOrder = function(ffOrderId, options = {}) {

--- a/test/js/api/order.js
+++ b/test/js/api/order.js
@@ -86,6 +86,19 @@ describe("OrderAPI", function() {
         });
     });
 
+    describe("#_getOrderImageURL()", function() {
+        it("should be able to generate the order image URL", async () => {
+            const remote = ripe.RipeAPI({ url: config.TEST_URL });
+            const result = remote._getOrderReportPNGURL(1234, "secret-key", {
+                params: { size: 100, format: "png" }
+            });
+            assert.strictEqual(
+                result,
+                `${config.TEST_URL}orders/1234/image?key=secret-key&size=100&format=png`
+            );
+        });
+    });
+
     describe("#importOrder()", function() {
         beforeEach(function() {
             if (!config.TEST_USERNAME || !config.TEST_PASSWORD) {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-sdk/issues/380 |
| Dependencies | -- |
| Decisions | Created method `_getOrderImageURL` which returns the built URL for the order image |
