### PR TITLE
#381 Fix `_getOrderReportURL`, `_getOrderReportPDFURL`, `_getOrderReportPNGURL` logic and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Support no `faces` in a dimension from spec in ´getDimension`
+* Fix `_getOrderReportURL`, `_getOrderReportPDFURL`, `_getOrderReportPNGURL` logic and tests - [#381](https://github.com/ripe-tech/ripe-sdk/pull/381)
 
 ## [2.25.0] - 2022-03-24
 

--- a/src/js/api/order.js
+++ b/src/js/api/order.js
@@ -2117,9 +2117,11 @@ ripe.Ripe.prototype.touchOrderP = function(number, options) {
 ripe.Ripe.prototype._getOrderReportURL = function(number, key, options) {
     options = options === undefined ? {} : options;
     const url = `${this.url}orders/${number}/report`;
+    const params = options.params || {};
+    params.key = key;
     options = Object.assign(options, {
         url: url,
-        params: { key: key }
+        params: params
     });
     return options.url + "?" + this._buildQuery(options.params);
 };
@@ -2130,9 +2132,11 @@ ripe.Ripe.prototype._getOrderReportURL = function(number, key, options) {
 ripe.Ripe.prototype._getOrderReportPDFURL = function(number, key, options) {
     options = options === undefined ? {} : options;
     const url = `${this.url}orders/${number}/report.pdf`;
+    const params = options.params || {};
+    params.key = key;
     options = Object.assign(options, {
         url: url,
-        params: { key: key }
+        params: params
     });
     return options.url + "?" + this._buildQuery(options.params);
 };
@@ -2143,9 +2147,11 @@ ripe.Ripe.prototype._getOrderReportPDFURL = function(number, key, options) {
 ripe.Ripe.prototype._getOrderReportPNGURL = function(number, key, options) {
     options = options === undefined ? {} : options;
     const url = `${this.url}orders/${number}/report.png`;
+    const params = options.params || {};
+    params.key = key;
     options = Object.assign(options, {
         url: url,
-        params: { key: key }
+        params: params
     });
     return options.url + "?" + this._buildQuery(options.params);
 };

--- a/test/js/api/order.js
+++ b/test/js/api/order.js
@@ -58,7 +58,7 @@ describe("OrderAPI", function() {
         it("should be able to generate a simple URL", async () => {
             const remote = ripe.RipeAPI({ url: config.TEST_URL });
             const result = remote._getOrderReportURL(1234, "secret-key", {
-                large: true
+                params: { large: true }
             });
             assert.strictEqual(
                 result,

--- a/test/js/api/order.js
+++ b/test/js/api/order.js
@@ -57,32 +57,39 @@ describe("OrderAPI", function() {
     describe("#_getOrderReportURL()", function() {
         it("should be able to generate a simple URL", async () => {
             const remote = ripe.RipeAPI({ url: config.TEST_URL });
-            const result = remote._getOrderReportURL(1234, "secret-key");
-            assert.strictEqual(result, `${config.TEST_URL}orders/1234/report?key=secret-key`);
-        });
-    });
-
-    describe("#_getOrderReportURL()", function() {
-        it("should be able to generate a simple URL", async () => {
-            const remote = ripe.RipeAPI({ url: config.TEST_URL });
-            const result = remote._getOrderReportURL(1234, "secret-key");
-            assert.strictEqual(result, `${config.TEST_URL}orders/1234/report?key=secret-key`);
+            const result = remote._getOrderReportURL(1234, "secret-key", {
+                large: true
+            });
+            assert.strictEqual(
+                result,
+                `${config.TEST_URL}orders/1234/report?key=secret-key&large=true`
+            );
         });
     });
 
     describe("#_getOrderReportPDFURL()", function() {
         it("should be able to generate a simple URL", async () => {
             const remote = ripe.RipeAPI({ url: config.TEST_URL });
-            const result = remote._getOrderReportPDFURL(1234, "secret-key");
-            assert.strictEqual(result, `${config.TEST_URL}orders/1234/report.pdf?key=secret-key`);
+            const result = remote._getOrderReportPDFURL(1234, "secret-key", {
+                params: { simple: true }
+            });
+            assert.strictEqual(
+                result,
+                `${config.TEST_URL}orders/1234/report.pdf?key=secret-key&simple=true`
+            );
         });
     });
 
-    describe("#_getOrderReportURL()", function() {
+    describe("#_getOrderReportPNGURL()", function() {
         it("should be able to generate a simple URL", async () => {
             const remote = ripe.RipeAPI({ url: config.TEST_URL });
-            const result = remote._getOrderReportPNGURL(1234, "secret-key");
-            assert.strictEqual(result, `${config.TEST_URL}orders/1234/report.png?key=secret-key`);
+            const result = remote._getOrderReportPNGURL(1234, "secret-key", {
+                params: { simple: true }
+            });
+            assert.strictEqual(
+                result,
+                `${config.TEST_URL}orders/1234/report.png?key=secret-key&simple=true`
+            );
         });
     });
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-sdk/issues/381 |
| Dependencies | -- |
| Decisions | Fixed methods `_getOrderReportURL`, `_getOrderReportPDFURL`, `_getOrderReportPNGURL` and their tests |
