### PR TITLE
version: 2.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+*
+
+## [2.25.1] - 2022-03-31
+
+### Fixed
+
 * Support no `faces` in a dimension from spec in ´getDimension`
 * Fix `_getOrderReportURL`, `_getOrderReportPDFURL`, `_getOrderReportPNGURL` logic and tests - [#381](https://github.com/ripe-tech/ripe-sdk/pull/381)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ripe-sdk",
-    "version": "2.25.0",
+    "version": "2.25.1",
     "description": "The public SDK for RIPE Core",
     "keywords": [
         "js",

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -16,7 +16,7 @@ if (
  * The version of the RIPE SDK currently in load, should
  * be in sync with the package information.
  */
-ripe.VERSION = "2.25.0";
+ripe.VERSION = "2.25.1";
 
 /**
  * Object that contains global (static) information to be used by


### PR DESCRIPTION
### Fixed

* Support no `faces` in a dimension from spec in ´getDimension`
* Fix `_getOrderReportURL`, `_getOrderReportPDFURL`, `_getOrderReportPNGURL` logic and tests - [#381](https://github.com/ripe-tech/ripe-sdk/pull/381)