### PR TITLE
YSL: Passing compose `options` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Added new compose `options` to allow passing composition options such as dpi and quality.
+* Added new compose `composeOptions` to allow passing composition options such as dpi and quality.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added method `resolveJustification` to find the matching justificaton given context and code or full code - [ripe-pulse/#317](https://github.com/ripe-tech/ripe-pulse/issues/317)
 * Added `remoteInitialsBuilderLogic` option to specify if the initials builder logic should run on server-side.  
 * Added `noAwaitLayout` option so that current updates don't wait for the previous ones to be complete.
+* Added new compose `options` to allow passing composition options such as dpi and quality.
 
 ### Changed
 

--- a/src/js/base/api.js
+++ b/src/js/base/api.js
@@ -1120,6 +1120,10 @@ ripe.Ripe.prototype._getImageOptions = function(options = {}) {
         params.logic = options.logic;
     }
 
+    if (options.options !== undefined && options.options !== null) {
+        params.options = options.options;
+    }
+
     const url = `${this.url}compose`;
 
     options = Object.assign(options, {

--- a/src/js/base/api.js
+++ b/src/js/base/api.js
@@ -1120,8 +1120,8 @@ ripe.Ripe.prototype._getImageOptions = function(options = {}) {
         params.logic = options.logic;
     }
 
-    if (options.composeOptions !== undefined && options.composeOptions !== null) {
-        params.options = options.composeOptions;
+    if (options.options !== undefined && options.options !== null) {
+        params.options = options.options;
     }
 
     const url = `${this.url}compose`;

--- a/src/js/base/api.js
+++ b/src/js/base/api.js
@@ -1120,8 +1120,8 @@ ripe.Ripe.prototype._getImageOptions = function(options = {}) {
         params.logic = options.logic;
     }
 
-    if (options.options !== undefined && options.options !== null) {
-        params.options = options.options;
+    if (options.composeOptions !== undefined && options.composeOptions !== null) {
+        params.options = options.composeOptions;
     }
 
     const url = `${this.url}compose`;

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -492,7 +492,7 @@ ripe.Image.prototype.update = async function(state, options = {}) {
             offsets: offsets,
             logic: composeLogic,
             curve: curve,
-            composeOptions: composeOptions
+            options: composeOptions
         });
 
         // verifies if the target image URL for the update is already

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -119,7 +119,7 @@ ripe.Image.prototype.init = function() {
         this.options.frameValidator === undefined
             ? (...args) => this.owner.hasFrame(...args)
             : this.options.frameValidator;
-    this.extraOptions = this.options.options || null;
+    this._options = this.options.options || null;
     this._observer = null;
     this._url = null;
     this._previousUrl = null;
@@ -257,7 +257,7 @@ ripe.Image.prototype.updateOptions = async function(options, update = true) {
         options.imageUrlProvider === undefined ? this.imageUrlProvider : options.imageUrlProvider;
     this.frameValidator =
         options.frameValidator === undefined ? this.frameValidator : options.frameValidator;
-    this.extraOptions = options.options === undefined ? this.extraOptions : options.options;
+    this._options = options.options === undefined ? this._options : options.options;
 
     if (update) await this.update();
 };
@@ -342,7 +342,7 @@ ripe.Image.prototype.update = async function(state, options = {}) {
         const curve = this.element.dataset.curve || this.curve;
         const doubleBuffering = this.element.dataset.doubleBuffering || this.doubleBuffering;
         const composeLogic = this.element.dataset.composeLogic || this.composeLogic || undefined;
-        const options = this.element.dataset.options || this.extraOptions;
+        const options = this.element.dataset.options || this._options;
 
         // in case the state is defined tries to gather the appropriate
         // sate options for both initials and engraving taking into

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -119,7 +119,7 @@ ripe.Image.prototype.init = function() {
         this.options.frameValidator === undefined
             ? (...args) => this.owner.hasFrame(...args)
             : this.options.frameValidator;
-    this.options = this.options.options || null;
+    this.extraOptions = this.options.options || null;
     this._observer = null;
     this._url = null;
     this._previousUrl = null;
@@ -341,7 +341,7 @@ ripe.Image.prototype.update = async function(state, options = {}) {
         const curve = this.element.dataset.curve || this.curve;
         const doubleBuffering = this.element.dataset.doubleBuffering || this.doubleBuffering;
         const composeLogic = this.element.dataset.composeLogic || this.composeLogic || undefined;
-        const options = this.element.dataset.options || this.options;
+        const options = this.element.dataset.options || this.extraOptions;
 
         // in case the state is defined tries to gather the appropriate
         // sate options for both initials and engraving taking into

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -120,6 +120,7 @@ ripe.Image.prototype.init = function() {
         this.options.frameValidator === undefined
             ? (...args) => this.owner.hasFrame(...args)
             : this.options.frameValidator;
+    this.options = this.options.options || this.owner.options || [];
     this._observer = null;
     this._url = null;
     this._previousUrl = null;
@@ -340,6 +341,7 @@ ripe.Image.prototype.update = async function(state, options = {}) {
         const offsets = this.element.dataset.offsets || this.offsets;
         const curve = this.element.dataset.curve || this.curve;
         const doubleBuffering = this.element.dataset.doubleBuffering || this.doubleBuffering;
+        const options = this.element.dataset.options || this.options;
         const remoteInitialsBuilderLogic =
             this.element.dataset.remoteInitialsBuilderLogic ||
             this.remoteInitialsBuilderLogic ||
@@ -484,7 +486,8 @@ ripe.Image.prototype.update = async function(state, options = {}) {
             shadowOffset: shadowOffset,
             offsets: offsets,
             logic: remoteInitialsBuilderLogic,
-            curve: curve
+            curve: curve,
+            options: options
         });
 
         // verifies if the target image URL for the update is already

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -119,7 +119,7 @@ ripe.Image.prototype.init = function() {
         this.options.frameValidator === undefined
             ? (...args) => this.owner.hasFrame(...args)
             : this.options.frameValidator;
-    this._options = this.options.options || null;
+    this.composeOptions = this.options.composeOptions || null;
     this._observer = null;
     this._url = null;
     this._previousUrl = null;
@@ -257,7 +257,8 @@ ripe.Image.prototype.updateOptions = async function(options, update = true) {
         options.imageUrlProvider === undefined ? this.imageUrlProvider : options.imageUrlProvider;
     this.frameValidator =
         options.frameValidator === undefined ? this.frameValidator : options.frameValidator;
-    this._options = options.options === undefined ? this._options : options.options;
+    this.composeOptions =
+        options.options === undefined ? this.composeOptions : options.composeOptions;
 
     if (update) await this.update();
 };
@@ -342,7 +343,7 @@ ripe.Image.prototype.update = async function(state, options = {}) {
         const curve = this.element.dataset.curve || this.curve;
         const doubleBuffering = this.element.dataset.doubleBuffering || this.doubleBuffering;
         const composeLogic = this.element.dataset.composeLogic || this.composeLogic || undefined;
-        const options = this.element.dataset.options || this._options;
+        const composeOptions = this.element.dataset.composeOptions || this.composeOptions;
 
         // in case the state is defined tries to gather the appropriate
         // sate options for both initials and engraving taking into
@@ -491,7 +492,7 @@ ripe.Image.prototype.update = async function(state, options = {}) {
             offsets: offsets,
             logic: composeLogic,
             curve: curve,
-            options: options
+            composeOptions: composeOptions
         });
 
         // verifies if the target image URL for the update is already

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -257,6 +257,7 @@ ripe.Image.prototype.updateOptions = async function(options, update = true) {
         options.imageUrlProvider === undefined ? this.imageUrlProvider : options.imageUrlProvider;
     this.frameValidator =
         options.frameValidator === undefined ? this.frameValidator : options.frameValidator;
+    this.extraOptions = options.options === undefined ? this.extraOptions : options.options;
 
     if (update) await this.update();
 };

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -120,7 +120,7 @@ ripe.Image.prototype.init = function() {
         this.options.frameValidator === undefined
             ? (...args) => this.owner.hasFrame(...args)
             : this.options.frameValidator;
-    this.options = this.options.options || this.owner.options || [];
+    this.options = this.options.options || this.owner.options || null;
     this._observer = null;
     this._url = null;
     this._previousUrl = null;

--- a/src/js/visual/image.js
+++ b/src/js/visual/image.js
@@ -120,7 +120,7 @@ ripe.Image.prototype.init = function() {
         this.options.frameValidator === undefined
             ? (...args) => this.owner.hasFrame(...args)
             : this.options.frameValidator;
-    this.options = this.options.options || this.owner.options || null;
+    this.options = this.options.options || null;
     this._observer = null;
     this._url = null;
     this._previousUrl = null;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | - Add missing option for composition `composeOptions` to be passed in the URL. This will allow us to do things like `options: ["locale:zh_cn"]` when doing bindImage. |
