### PR TITLE
version: 2.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 *
 
-## [2.27.0] - 2022-04-18
+## [2.28.0] - 2022-04-18
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ripe-sdk",
-    "version": "2.27.0",
+    "version": "2.28.0",
     "description": "The public SDK for RIPE Core",
     "keywords": [
         "js",

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -16,7 +16,7 @@ if (
  * The version of the RIPE SDK currently in load, should
  * be in sync with the package information.
  */
-ripe.VERSION = "2.27.0";
+ripe.VERSION = "2.28.0";
 
 /**
  * Object that contains global (static) information to be used by


### PR DESCRIPTION
This fixes an npmjs error for duplicated tag that was created before the release of 2.27.0 and the deployment failed with the message `You cannot publish over the previously published versions: 2.27.0.`

Here's the workflow with the error of the deployment https://github.com/ripe-tech/ripe-sdk/runs/6062181012?check_suite_focus=true

Note: I had to remove the tag 2.27.0 as it was being problematic
