### PR TITLE
Add `safe` import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Added `safe` param to be passed in `importOrder` - [ripe-util-vue/#259](https://github.com/ripe-tech/ripe-util-vue/issues/259)
 
 ### Changed
 

--- a/src/js/api/order.js
+++ b/src/js/api/order.js
@@ -2285,6 +2285,7 @@ ripe.Ripe.prototype._importOrder = function(ffOrderId, options = {}) {
     const invoicingInfo = options.invoicingInfo === undefined ? null : options.invoicingInfo;
     const notes = options.notes === undefined ? null : options.notes;
     const images = options.images === undefined ? null : options.images;
+    const safe = options.safe === undefined ? null : options.safe;
 
     const url = `${this.url}orders/import`;
     const contents = {
@@ -2323,6 +2324,7 @@ ripe.Ripe.prototype._importOrder = function(ffOrderId, options = {}) {
     if (notes) params.notes = notes;
     if (notify) params.notify = notify;
     if (pending) params.pending = pending;
+    if (safe !== undefined) params.safe = safe;
 
     return Object.assign(options, {
         url: url,


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-util-vue/issues/259 |
| Decisions | For the issue referenced, there was a possibility of collision between `ff_order_id`s, and there was no way from outside the `sdk` to force the creation of an order passing the `safe` flag as false. This addresses that feature in a backwards-compatible way. |
