### PR TITLE
#135 Add `fromArrayBuffer` and `fromBlob` to `FileTuple`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Add `fromArrayBuffer` and `fromBlob` to `FileTuple` - [hermes-proxy/135](https://github.com/ripe-tech/hermes-proxy/issues/135)
 
 ### Changed
 

--- a/src/js/base/struct.js
+++ b/src/js/base/struct.js
@@ -28,6 +28,16 @@ ripe.FileTuple.fromString = function(dataString, name = null, mime = null) {
     return this.fromData(data, name, mime);
 };
 
+ripe.FileTuple.fromArrayBuffer = function(arrayBuffer, name = null, mime = null) {
+    const buffer = Buffer.from(arrayBuffer);
+    return this.fromData(buffer, name, mime);
+};
+
+ripe.FileTuple.fromBlob = async function(blob, name = null, mime = null) {
+    const arrayBuffer = await blob.arrayBuffer();
+    return this.fromArrayBuffer(arrayBuffer, name, mime);
+};
+
 ripe.FileTuple.prototype.toString = function() {
     return "[object Array]";
 };

--- a/test/js/base/struct.js
+++ b/test/js/base/struct.js
@@ -38,6 +38,12 @@ describe("FileTuple", function() {
     });
 
     describe("#fromString()", async function() {
+        beforeEach(function() {
+            if (typeof TextEncoder === "undefined") {
+                this.skip();
+            }
+        });
+
         it("should be able to create a simple file tuple objects", () => {
             const fileTuple = ripe.ripe.FileTuple.fromString("hello", "hello.txt", "text/plain");
             assert.notStrictEqual(fileTuple, null);
@@ -51,6 +57,12 @@ describe("FileTuple", function() {
     });
 
     describe("#fromArrayBuffer()", async function() {
+        beforeEach(function() {
+            if (typeof TextEncoder === "undefined") {
+                this.skip();
+            }
+        });
+
         it("should be able to create a simple file tuple objects", () => {
             const fileTuple = ripe.ripe.FileTuple.fromArrayBuffer(
                 new ArrayBuffer(),
@@ -69,7 +81,7 @@ describe("FileTuple", function() {
 
     describe("#fromBlob()", async function() {
         beforeEach(function() {
-            if (typeof Blob === "undefined") {
+            if (typeof TextEncoder === "undefined" || typeof Blob === "undefined") {
                 this.skip();
             }
         });

--- a/test/js/base/struct.js
+++ b/test/js/base/struct.js
@@ -57,12 +57,6 @@ describe("FileTuple", function() {
     });
 
     describe("#fromArrayBuffer()", async function() {
-        beforeEach(function() {
-            if (typeof TextEncoder === "undefined") {
-                this.skip();
-            }
-        });
-
         it("should be able to create a simple file tuple objects", () => {
             const fileTuple = ripe.ripe.FileTuple.fromArrayBuffer(
                 new ArrayBuffer(),
@@ -81,7 +75,7 @@ describe("FileTuple", function() {
 
     describe("#fromBlob()", async function() {
         beforeEach(function() {
-            if (typeof TextEncoder === "undefined" || typeof Blob === "undefined") {
+            if (typeof Blob === "undefined") {
                 this.skip();
             }
         });

--- a/test/js/base/struct.js
+++ b/test/js/base/struct.js
@@ -1,8 +1,7 @@
 const assert = require("assert");
+const buffer = require("buffer");
 const config = require("../config");
 const ripe = require("../../../src/js");
-
-const { Blob } = require("buffer");
 
 describe("FileTuple", function() {
     this.timeout(config.TEST_TIMEOUT);
@@ -75,14 +74,14 @@ describe("FileTuple", function() {
 
     describe("#fromBlob()", async function() {
         beforeEach(function() {
-            if (typeof Blob === "undefined") {
+            if (typeof buffer.Blob === "undefined") {
                 this.skip();
             }
         });
 
         it("should be able to create a simple file tuple objects", async () => {
             const fileTuple = await ripe.ripe.FileTuple.fromBlob(
-                new Blob(),
+                new buffer.Blob(),
                 "hello.txt",
                 "text/plain"
             );

--- a/test/js/base/struct.js
+++ b/test/js/base/struct.js
@@ -42,12 +42,11 @@ describe("FileTuple", function() {
             const fileTuple = ripe.ripe.FileTuple.fromString("hello", "hello.txt", "text/plain");
             assert.notStrictEqual(fileTuple, null);
             assert.strictEqual(fileTuple.constructor, ripe.ripe.FileTuple);
-            assert.strictEqual(fileTuple.name, "hello.txt");
-            assert.strictEqual(fileTuple.mime, "text/plain");
-            assert.strictEqual(fileTuple.data.byteLength, 5);
+            assert.strictEqual(fileTuple.name(), "hello.txt");
+            assert.strictEqual(fileTuple.mime(), "text/plain");
+            assert.strictEqual(fileTuple.data().byteLength, 5);
             assert.strictEqual(fileTuple instanceof ripe.ripe.FileTuple, true);
             assert.strictEqual(fileTuple instanceof Array, true);
-            assert.strictEqual(Array.isArray(fileTuple), true);
         });
     });
 
@@ -60,16 +59,21 @@ describe("FileTuple", function() {
             );
             assert.notStrictEqual(fileTuple, null);
             assert.strictEqual(fileTuple.constructor, ripe.ripe.FileTuple);
-            assert.strictEqual(fileTuple.name, "hello.txt");
-            assert.strictEqual(fileTuple.mime, "text/plain");
-            assert.strictEqual(fileTuple.data.byteLength, 0);
+            assert.strictEqual(fileTuple.name(), "hello.txt");
+            assert.strictEqual(fileTuple.mime(), "text/plain");
+            assert.strictEqual(fileTuple.data().byteLength, 0);
             assert.strictEqual(fileTuple instanceof ripe.ripe.FileTuple, true);
             assert.strictEqual(fileTuple instanceof Array, true);
-            assert.strictEqual(Array.isArray(fileTuple), true);
         });
     });
 
     describe("#fromBlob()", async function() {
+        beforeEach(function() {
+            if (typeof Blob === "undefined") {
+                this.skip();
+            }
+        });
+
         it("should be able to create a simple file tuple objects", async () => {
             const fileTuple = await ripe.ripe.FileTuple.fromBlob(
                 new Blob(),
@@ -78,12 +82,11 @@ describe("FileTuple", function() {
             );
             assert.notStrictEqual(fileTuple, null);
             assert.strictEqual(fileTuple.constructor, ripe.ripe.FileTuple);
-            assert.strictEqual(fileTuple.name, "hello.txt");
-            assert.strictEqual(fileTuple.mime, "text/plain");
-            assert.strictEqual(fileTuple.data.byteLength, 0);
+            assert.strictEqual(fileTuple.name(), "hello.txt");
+            assert.strictEqual(fileTuple.mime(), "text/plain");
+            assert.strictEqual(fileTuple.data().byteLength, 0);
             assert.strictEqual(fileTuple instanceof ripe.ripe.FileTuple, true);
             assert.strictEqual(fileTuple instanceof Array, true);
-            assert.strictEqual(Array.isArray(fileTuple), true);
         });
     });
 });

--- a/test/js/base/struct.js
+++ b/test/js/base/struct.js
@@ -2,6 +2,8 @@ const assert = require("assert");
 const config = require("../config");
 const ripe = require("../../../src/js");
 
+const { Blob } = require("buffer");
+
 describe("FileTuple", function() {
     this.timeout(config.TEST_TIMEOUT);
 
@@ -32,6 +34,56 @@ describe("FileTuple", function() {
             assert.strictEqual(fileTuple.data().byteLength, 0);
             assert.strictEqual(fileTuple instanceof ripe.ripe.FileTuple, true);
             assert.strictEqual(fileTuple instanceof Array, true);
+        });
+    });
+
+    describe("#fromString()", async function() {
+        it("should be able to create a simple file tuple objects", () => {
+            const fileTuple = ripe.ripe.FileTuple.fromString("hello", "hello.txt", "text/plain");
+            assert.notStrictEqual(fileTuple, null);
+            assert.strictEqual(fileTuple.constructor, ripe.ripe.FileTuple);
+            assert.strictEqual(fileTuple.name, "hello.txt");
+            assert.strictEqual(fileTuple.mime, "text/plain");
+            assert.strictEqual(fileTuple.data.byteLength, 5);
+            assert.strictEqual(fileTuple instanceof ripe.ripe.FileTuple, true);
+            assert.strictEqual(fileTuple instanceof Array, true);
+            assert.strictEqual(Array.isArray(fileTuple), true);
+        });
+    });
+
+    describe("#fromArrayBuffer()", async function() {
+        it("should be able to create a simple file tuple objects", () => {
+            const fileTuple = ripe.ripe.FileTuple.fromArrayBuffer(
+                new ArrayBuffer(),
+                "hello.txt",
+                "text/plain"
+            );
+            assert.notStrictEqual(fileTuple, null);
+            assert.strictEqual(fileTuple.constructor, ripe.ripe.FileTuple);
+            assert.strictEqual(fileTuple.name, "hello.txt");
+            assert.strictEqual(fileTuple.mime, "text/plain");
+            assert.strictEqual(fileTuple.data.byteLength, 0);
+            assert.strictEqual(fileTuple instanceof ripe.ripe.FileTuple, true);
+            assert.strictEqual(fileTuple instanceof Array, true);
+            assert.strictEqual(Array.isArray(fileTuple), true);
+        });
+    });
+
+    describe("#fromBlob()", async function() {
+        it("should be able to create a simple file tuple objects", async () => {
+            const fileTuple = await ripe.ripe.FileTuple.fromBlob(
+                new Blob(),
+                "hello.txt",
+                "text/plain"
+            );
+            assert.notStrictEqual(fileTuple, null);
+            assert.strictEqual(fileTuple.constructor, ripe.ripe.FileTuple);
+            assert.strictEqual(fileTuple.name, "hello.txt");
+            assert.strictEqual(fileTuple.mime, "text/plain");
+            assert.strictEqual(fileTuple.data.byteLength, 0);
+            assert.strictEqual(fileTuple instanceof ripe.ripe.FileTuple, true);
+            assert.strictEqual(fileTuple instanceof Array, true);
+            assert.strictEqual(Array.isArray(fileTuple), true);
         });
     });
 });


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Port from https://github.com/hivesolutions/yonius/pull/39 (related to https://github.com/ripe-tech/hermes-proxy/issues/135) |
| Dependencies | -- |
| Decisions | • Add `fromArrayBuffer` and `fromBlob` to `FileTuple`<br>• Add tests: `#fromString()`, `#fromArrayBuffer()` and `#fromBlob()` |

![imagem](https://user-images.githubusercontent.com/22588915/168312550-125aec24-9200-41cf-955a-0d7c92667167.png)

![imagem](https://user-images.githubusercontent.com/22588915/168312664-4b3728c7-730b-4aea-a382-dfa2581a555d.png)
