### PR TITLE
version: 2.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Add `fromArrayBuffer` and `fromBlob` to `FileTuple` - [hermes-proxy/135](https://github.com/ripe-tech/hermes-proxy/issues/135)
-* Added `safe` param to be passed in `importOrder` - [ripe-util-vue/#259](https://github.com/ripe-tech/ripe-util-vue/issues/259)
-* Support profile overriding in image - [ripe-white/#978](https://github.com/ripe-tech/ripe-white/issues/978)
+*
 
 ### Changed
 
@@ -20,6 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 *
+
+## [2.30.0] - 2022-05-20
+
+### Added
+
+* Add `fromArrayBuffer` and `fromBlob` to `FileTuple` - [hermes-proxy/135](https://github.com/ripe-tech/hermes-proxy/issues/135)
+* Added `safe` param to be passed in `importOrder` - [ripe-util-vue/#259](https://github.com/ripe-tech/ripe-util-vue/issues/259)
+* Support profile overriding in image - [ripe-white/#978](https://github.com/ripe-tech/ripe-white/issues/978)
 
 ## [2.29.0] - 2022-04-28
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ripe-sdk",
-    "version": "2.29.0",
+    "version": "2.30.0",
     "description": "The public SDK for RIPE Core",
     "keywords": [
         "js",

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -16,7 +16,7 @@ if (
  * The version of the RIPE SDK currently in load, should
  * be in sync with the package information.
  */
-ripe.VERSION = "2.29.0";
+ripe.VERSION = "2.30.0";
 
 /**
  * Object that contains global (static) information to be used by


### PR DESCRIPTION
### Added

* Add `fromArrayBuffer` and `fromBlob` to `FileTuple` - [hermes-proxy/135](https://github.com/ripe-tech/hermes-proxy/issues/135)
* Added `safe` param to be passed in `importOrder` - [ripe-util-vue/#259](https://github.com/ripe-tech/ripe-util-vue/issues/259)
* Support profile overriding in image - [ripe-white/#978](https://github.com/ripe-tech/ripe-white/issues/978)