### PR TITLE
version: 2.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+*
+
+### Changed
+
+*
+
+### Fixed
+
+*
+
+## [2.31.0] - 2022-06-01
+
+### Added
+
 * Added `deleteTagOrder` methods - [ripe-robin-revamp/#363](https://github.com/ripe-tech/ripe-robin-revamp/issues/363)
 * Added `deactivateTagOrder` methods - [ripe-robin-revamp/#363](https://github.com/ripe-tech/ripe-robin-revamp/issues/363)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ripe-sdk",
-    "version": "2.30.0",
+    "version": "2.31.0",
     "description": "The public SDK for RIPE Core",
     "keywords": [
         "js",

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -16,7 +16,7 @@ if (
  * The version of the RIPE SDK currently in load, should
  * be in sync with the package information.
  */
-ripe.VERSION = "2.30.0";
+ripe.VERSION = "2.31.0";
 
 /**
  * Object that contains global (static) information to be used by


### PR DESCRIPTION
### Added

* Added `deleteTagOrder` methods - [ripe-robin-revamp/#363](https://github.com/ripe-tech/ripe-robin-revamp/issues/363)
* Added `deactivateTagOrder` methods - [ripe-robin-revamp/#363](https://github.com/ripe-tech/ripe-robin-revamp/issues/363)

### Changed

* Removed node 10 and 11 from github workflows

### Fixed

* Fix eslint dependencies problems