### PR TITLE
#363 Tag: Add param `tenent_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Add param `tenant_id` to `updateTagOrder` method - [ripe-robin-revamp/#363](https://github.com/ripe-tech/ripe-robin-revamp/issues/363)
 
 ### Changed
 

--- a/src/js/api/order.js
+++ b/src/js/api/order.js
@@ -2137,6 +2137,7 @@ ripe.Ripe.prototype.updateTagOrder = function(number, identifier, type, options,
     options.params.identifier = identifier;
     options.params.type = type;
     if (options.activate !== undefined) options.params.activate = options.activate;
+    if (options.tenant_id !== undefined) options.params.tenant_id = options.tenant_id;
     options = this._build(options);
     return this._cacheURL(options.url, options, callback);
 };

--- a/src/js/api/order.js
+++ b/src/js/api/order.js
@@ -2137,7 +2137,7 @@ ripe.Ripe.prototype.updateTagOrder = function(number, identifier, type, options,
     options.params.identifier = identifier;
     options.params.type = type;
     if (options.activate !== undefined) options.params.activate = options.activate;
-    if (options.tenant_id !== undefined) options.params.tenant_id = options.tenant_id;
+    if (options.tenantId !== undefined) options.params.tenant_id = options.tenantId;
     options = this._build(options);
     return this._cacheURL(options.url, options, callback);
 };


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-robin-revamp/issues/363 |
| Dependencies | https://github.com/ripe-tech/ripe-core/pull/4740 |
| Decisions | -  Add param `tenant_id` to `updateTagOrder` method |

