### PR TITLE
fix: import order DKU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* Add dku to request options for import order
+* Add `dku` to request options for import order
+* Add `contents` to params of import order only if filled with some value
 
 ## [2.31.2] - 2022-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Add dku to request options for import order
 
 ## [2.31.2] - 2022-06-08
 

--- a/src/js/api/order.js
+++ b/src/js/api/order.js
@@ -2371,12 +2371,11 @@ ripe.Ripe.prototype._importOrder = function(ffOrderId, options = {}) {
     const safe = options.safe === undefined ? null : options.safe ? "1" : "0";
 
     const url = `${this.url}orders/import`;
-    const contents = {
-        brand: brand,
-        model: model,
-        parts: parts,
-        size: size
-    };
+    const contents = {};
+    if (brand) contents.brand = brand;
+    if (model) contents.model = model;
+    if (parts) contents.parts = parts;
+    if (size) contents.size = size;
 
     if (factory) contents.factory = factory;
     if (variant) contents.variant = variant;
@@ -2397,9 +2396,9 @@ ripe.Ripe.prototype._importOrder = function(ffOrderId, options = {}) {
     if (invoicingInfo) contents.invoicing_info = invoicingInfo;
 
     const params = {
-        ff_order_id: ffOrderId,
-        contents: JSON.stringify(contents)
+        ff_order_id: ffOrderId
     };
+    if (Object.keys(contents).length > 0) params.contents = JSON.stringify(contents);
     if (dku) params.dku = dku;
     if (type) params.type = type;
     if (country) params.country = country;

--- a/src/js/api/order.js
+++ b/src/js/api/order.js
@@ -2437,6 +2437,7 @@ ripe.Ripe.prototype._precustomizationOrder = function(ffId, options = {}) {
             ? null
             : options.product_id || options.productId;
     const meta = options.meta === undefined ? null : options.meta;
+    const dku = options.dku === undefined ? null : options.dku;
 
     const url = `${this.url}orders/pre_customization`;
     const contents = {
@@ -2460,6 +2461,7 @@ ripe.Ripe.prototype._precustomizationOrder = function(ffId, options = {}) {
         contents: JSON.stringify(contents)
     };
     if (meta) params.meta = meta;
+    if (dku) params.dku = dku;
 
     return Object.assign(options, {
         url: url,

--- a/src/js/api/order.js
+++ b/src/js/api/order.js
@@ -2374,7 +2374,7 @@ ripe.Ripe.prototype._importOrder = function(ffOrderId, options = {}) {
     const contents = {};
     if (brand) contents.brand = brand;
     if (model) contents.model = model;
-    if (parts) contents.parts = parts;
+    if (Object.keys(parts).length > 0) contents.parts = parts;
     if (size) contents.size = size;
 
     if (factory) contents.factory = factory;

--- a/src/js/api/order.js
+++ b/src/js/api/order.js
@@ -2336,6 +2336,7 @@ ripe.Ripe.prototype._getOrderImageURL = function(number, key, options) {
  * @see {link https://docs.platforme.com/#order-endpoints-import}
  */
 ripe.Ripe.prototype._importOrder = function(ffOrderId, options = {}) {
+    const dku = options.dku === undefined ? null : options.dku;
     const type = options.type === undefined ? null : options.type;
     const brand = options.brand === undefined ? this.brand : options.brand;
     const factory = options.factory === undefined ? null : options.factory;
@@ -2399,6 +2400,7 @@ ripe.Ripe.prototype._importOrder = function(ffOrderId, options = {}) {
         ff_order_id: ffOrderId,
         contents: JSON.stringify(contents)
     };
+    if (dku) params.dku = dku;
     if (type) params.type = type;
     if (country) params.country = country;
     if (currency) params.currency = currency;
@@ -2437,7 +2439,6 @@ ripe.Ripe.prototype._precustomizationOrder = function(ffId, options = {}) {
             ? null
             : options.product_id || options.productId;
     const meta = options.meta === undefined ? null : options.meta;
-    const dku = options.dku === undefined ? null : options.dku;
 
     const url = `${this.url}orders/pre_customization`;
     const contents = {
@@ -2461,7 +2462,6 @@ ripe.Ripe.prototype._precustomizationOrder = function(ffId, options = {}) {
         contents: JSON.stringify(contents)
     };
     if (meta) params.meta = meta;
-    if (dku) params.dku = dku;
 
     return Object.assign(options, {
         url: url,

--- a/test/js/api/order.js
+++ b/test/js/api/order.js
@@ -198,7 +198,8 @@ describe("OrderAPI", function() {
                 type: "buildless",
                 brand: "dummy",
                 model: "dummy",
-                price: 30
+                price: 30,
+                size: 17
             });
             assert.strictEqual(result.ff_order_id, ffOrderId);
             assert.strictEqual(result.type, "buildless");


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | Contents filled only if there are values. If there are none, dont send an object with null values. Pass DKU if it exists. Add a size to import order.<br> Passing no size, previously, we had a contents like `{ size: null }` and this does not fail when importing. Meaning there is some bug in Core, to be fixed in another PR. |
| Animated GIF | -- |
