### PR TITLE
#4745 Add `variant` and `size` params to `_getConfigOptions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Add new `variant` and `size` params to `_getConfigOptions` method - [ripe-core/#4745](https://github.com/ripe-tech/ripe-core/issues/4745)
 
 ### Changed
 

--- a/src/js/api/brand.js
+++ b/src/js/api/brand.js
@@ -688,8 +688,8 @@ ripe.Ripe.prototype._getMeshOptions = function(options = {}) {
 ripe.Ripe.prototype._getConfigOptions = function(options = {}) {
     const brand = options.brand === undefined ? this.brand : options.brand;
     const model = options.model === undefined ? this.model : options.model;
-    const variant = options.variant === undefined ? this.variant : options.variant;
     const version = options.version === undefined ? this.version : options.version;
+    const variant = options.variant === undefined ? this.variant : options.variant;
     const size = options.size === undefined ? this.size : options.size;
     const country = options.country === undefined ? this.country : options.country;
     const flag = options.flag === undefined ? this.flag : options.flag;

--- a/src/js/api/brand.js
+++ b/src/js/api/brand.js
@@ -688,13 +688,21 @@ ripe.Ripe.prototype._getMeshOptions = function(options = {}) {
 ripe.Ripe.prototype._getConfigOptions = function(options = {}) {
     const brand = options.brand === undefined ? this.brand : options.brand;
     const model = options.model === undefined ? this.model : options.model;
+    const variant = options.variant === undefined ? this.variant : options.variant;
     const version = options.version === undefined ? this.version : options.version;
+    const size = options.size === undefined ? this.size : options.size;
     const country = options.country === undefined ? this.country : options.country;
     const flag = options.flag === undefined ? this.flag : options.flag;
     const url = `${this.url}brands/${brand}/models/${model}/config`;
     const params = {};
+    if (variant !== undefined && variant !== null) {
+        params.variant = variant;
+    }
     if (version !== undefined && version !== null) {
         params.version = version;
+    }
+    if (size !== undefined && size !== null) {
+        params.size = size;
     }
     if (country !== undefined && country !== null) {
         params.country = country;

--- a/src/js/api/brand.js
+++ b/src/js/api/brand.js
@@ -695,11 +695,11 @@ ripe.Ripe.prototype._getConfigOptions = function(options = {}) {
     const flag = options.flag === undefined ? this.flag : options.flag;
     const url = `${this.url}brands/${brand}/models/${model}/config`;
     const params = {};
-    if (variant !== undefined && variant !== null) {
-        params.variant = variant;
-    }
     if (version !== undefined && version !== null) {
         params.version = version;
+    }
+    if (variant !== undefined && variant !== null) {
+        params.variant = variant;
     }
     if (size !== undefined && size !== null) {
         params.size = size;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-core/issues/4745 |
| Decisions | - Add new `variant` and `size` params to `_getConfigOptions` method |
