### PR TITLE
Dcoument required CSS `link` for configurator to work properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Add new `variant` and `size` params to `_getConfigOptions` method - [ripe-core/#4745](https://github.com/ripe-tech/ripe-core/issues/4745)
 * Add `variant` passing through `onConfig` and `onPart`
+* Add CSS `link` to `README.md`
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,18 @@ When using RIPE SDK in a web context, include it via a `<script>` tag, such as:
 
 ```html
 <script type="text/javascript" src="https://sdk.platforme.com/js/ripe.min.js"></script>
-<link type="text/css" rel="stylesheet" href="https://sdk.platforme.com/css/ripe.css">
 ```
 
 When using RIPE SDK in a NPM compatible context, use as such:
 
 ```bash
 npm install --save ripe-sdk
+```
+
+If using the configurator include the needed CSS tag, such as:
+
+```html
+<link rel="stylesheet" type="text/css" href="https://sdk.platforme.com/css/ripe.css">
 ```
 
 ## 1. Initialization

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ When using RIPE SDK in a web context, include it via a `<script>` tag, such as:
 
 ```html
 <script type="text/javascript" src="https://sdk.platforme.com/js/ripe.min.js"></script>
+<link type="text/css" rel="stylesheet" href="https://sdk.platforme.com/css/ripe.css">
 ```
 
 When using RIPE SDK in a NPM compatible context, use as such:


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | If the user doesn't add the CSS `link` the configurator won't work properly |
| Dependencies | -- |
| Decisions | Document how to include the CSS link |

Issue:

https://user-images.githubusercontent.com/22588915/187227122-b49b9add-96ec-43e6-aa8a-0470e3a8e0c4.mp4

