### PR TITLE
Add `hasStrategy` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Add new `variant` and `size` params to `_getConfigOptions` method - [ripe-core/#4745](https://github.com/ripe-tech/ripe-core/issues/4745)
 * Add `variant` passing through `onConfig` and `onPart`
+* Add `hasStrategy` method
 
 ### Changed
 
-*
+* Ensures the configurator strategy is supported before advancing with it's setup
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Ensures the configurator strategy is supported before advancing with it's setup
+*
 
 ### Fixed
 

--- a/src/js/base/config.js
+++ b/src/js/base/config.js
@@ -41,3 +41,8 @@ ripe.Ripe.prototype.hasSize = function() {
 ripe.Ripe.prototype.hasInitialsRadius = function() {
     return !this.hasTag("initials_no_radius");
 };
+
+ripe.Ripe.prototype.hasStrategy = function(strategy) {
+    const strategies = (this.loadedConfig && this.loadedConfig.strategies) || ["prc"];
+    return strategies.includes(strategy);
+};

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -1219,12 +1219,6 @@ ripe.Ripe.prototype.bindVideoThumbnail = function(element, options = {}) {
  */
 ripe.Ripe.prototype.bindConfigurator = function(element, options = {}) {
     options = Object.assign({}, { format: this.format }, options);
-
-    const strategyType = options.type || "prc";
-    if (!this.hasStrategy(strategyType)) {
-        throw Error(`Strategy type "${strategyType}" not supported`);
-    }
-
     switch (options.type) {
         case "csr":
             return this.bindConfiguratorCsr(element, options);

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -1219,6 +1219,12 @@ ripe.Ripe.prototype.bindVideoThumbnail = function(element, options = {}) {
  */
 ripe.Ripe.prototype.bindConfigurator = function(element, options = {}) {
     options = Object.assign({}, { format: this.format }, options);
+
+    const strategyType = options.type || "prc";
+    if (!this.hasStrategy(strategyType)) {
+        throw Error(`Strategy type "${strategyType}" not supported`);
+    }
+
     switch (options.type) {
         case "csr":
             return this.bindConfiguratorCsr(element, options);


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | Add the method `hasStrategy` which checks if a build has a specific strategy. It does that by checking the config `strategies` array values for a match. If a build doesn't have `strategies` variable it will check against "prc" as it's our default strategy |
