### PR TITLE
Set renderer output encoding to `sRGBEncoding`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Avoid warnings by not using `var` in ripe-sdk-demo .js files
+* Set renderer output encoding to `sRGBEncoding`
 
 ### Fixed
 

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -412,6 +412,7 @@ ripe.ConfiguratorCsr.prototype._initCsr = async function() {
 
     // init renderer
     this.renderer = new window.THREE.WebGLRenderer({ antialias: true, alpha: true });
+    this.renderer.outputEncoding = window.THREE.sRGBEncoding;
     this.renderer.setPixelRatio(this.pixelRatio);
     this.renderer.setSize(size.width, size.height);
     this.renderer.setAnimationLoop(() => this._onAnimationLoop(this));

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -65,6 +65,13 @@ ripe.ConfiguratorCsr.prototype.init = function() {
     this.pixelRatio =
         this.options.pixelRatio || (typeof window !== "undefined" && window.devicePixelRatio) || 2;
     this.sensitivity = this.options.sensitivity || 40;
+    const rendererOpts = this.options.rendererOptions || {};
+    this.rendererOptions = {
+        outputEncoding:
+            rendererOpts.outputEncoding !== undefined
+                ? rendererOpts.outputEncoding
+                : window.THREE.sRGBEncoding
+    };
     this.useDracoLoader =
         this.options.useDracoLoader !== undefined ? this.options.useDracoLoader : true;
     this.dracoLoaderDecoderPath =
@@ -149,6 +156,8 @@ ripe.ConfiguratorCsr.prototype.updateOptions = async function(options, update = 
     this.size = options.size === undefined ? this.size : options.size;
     this.pixelRatio = options.pixelRatio === undefined ? this.pixelRatio : options.pixelRatio;
     this.sensitivity = options.sensitivity === undefined ? this.sensitivity : options.sensitivity;
+    const rendererOpts = options.rendererOptions || {};
+    this.rendererOptions = { ...this.rendererOptions, ...rendererOpts };
     this.useDracoLoader =
         options.useDracoLoader === undefined ? this.useDracoLoader : options.useDracoLoader;
     this.dracoLoaderDecoderPath =


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | By default the renderer uses linear encoding. Changing to `sRGBEncoding` will improve the mesh color accuracy |
| Dependencies | -- |
| Decisions | Set renderer output encoding to `sRGBEncoding` by default |
