### PR TITLE
Greatly improve CSR scene loading time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Set CSR camera default values standard
 * Use `THREE.Group` to manipulate positions and rotations instead of directly changing mesh axis
 * Improve animation loop so it can tick animations
+* Greatly improve CSR scene loading time
 
 ### Fixed
 

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -516,17 +516,21 @@ ripe.ConfiguratorCsr.prototype._loadScene = async function() {
     // inits the scene clock
     this.clock = new window.THREE.Clock();
 
-    // loads and sets scene environment
-    this.environmentTexture = await this._loadEnvironment(this.sceneEnvironmentPath);
+    // loads resources
+    const meshPath = this.owner.getMeshUrl();
+    [this.environmentTexture, this.mesh] = await Promise.all([
+        this._loadEnvironment(this.sceneEnvironmentPath),
+        this._loadMesh(meshPath)
+    ]);
+
+    // sets the scene environment
     this.environmentTexture.mapping = window.THREE.EquirectangularReflectionMapping;
     this.scene.environment = this.environmentTexture;
 
     // inits the scene model group
     this.modelGroup = new window.THREE.Group();
 
-    // loads and sets the model mesh
-    const meshPath = this.owner.getMeshUrl();
-    this.mesh = await this._loadMesh(meshPath);
+    // sets the model mesh
     this.modelGroup.add(this.mesh);
 
     this.scene.add(this.modelGroup);


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | CSR loading time has a lot of room for improvements |
| Dependencies | https://github.com/ripe-tech/ripe-sdk/pull/414 |
| Decisions | Paralellize CSR scene resource loading operations thus greatly decreasing loading times. From my quick tests it went from an avg. of 2209ms to 1346ms (863ms difference) |
