### PR TITLE
Fix CSR configurator no being hidden at the demo start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add `dku` to request options for import order
 * Add `contents` to params of import order only if filled with some value
 * Fix `ConfiguratorCsr` sizes and `resize()` logic
+* Fix CSR configurator no being hidden at the demo start
 
 ## [2.31.2] - 2022-06-08
 

--- a/src/python/ripe_demo/static/js/main.js
+++ b/src/python/ripe_demo/static/js/main.js
@@ -114,6 +114,8 @@ window.onload = function() {
     const init = function(instance) {
         // force PRC visualizer to appear at the start
         const prcElement = document.getElementById("configurator-prc");
+        const csrElement = document.getElementById("configurator-csr");
+        csrElement.style.display = "none";
         prcElement.style.display = "block";
         visibleConfigurator = "prc";
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Forgot to hide the CSR configurator on the start of the demo |
| Dependencies | -- |
| Decisions | Hide CSR configurator at the demo start |
