### PR TITLE
Fix not being able to override camera transforms on init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add `contents` to params of import order only if filled with some value
 * Fix `ConfiguratorCsr` sizes and `resize()` logic
 * Fix CSR configurator no being hidden at the demo start
+* Fix not being able to override camera transforms on CSR configurator initialization
 
 ## [2.31.2] - 2022-06-08
 

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -100,9 +100,9 @@ ripe.ConfiguratorCsr.prototype.init = function() {
             cameraOpts.updateAspectOnResize !== undefined ? cameraOpts.updateAspectOnResize : true,
         near: cameraOpts.near !== undefined ? cameraOpts.near : 0.1,
         far: cameraOpts.far !== undefined ? cameraOpts.far : 10000,
-        position: { x: 0, y: 0, z: 207 },
-        rotation: { x: 0, y: 0, z: 0 },
-        scale: { x: 1, y: 1, z: 1 },
+        position: cameraOpts.position !== undefined ? cameraOpts.position : { x: 0, y: 0, z: 207 },
+        rotation: cameraOpts.rotation !== undefined ? cameraOpts.rotation : { x: 0, y: 0, z: 0 },
+        scale: cameraOpts.scale !== undefined ? cameraOpts.scale : { x: 1, y: 1, z: 1 },
         lookAt: cameraOpts.lookAt !== undefined ? cameraOpts.lookAt : null
     };
     const zoomOpts = this.options.zoomOptions || {};


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Forgot to add override support for CSR camera transforms |
| Dependencies | -- |
| Decisions | Allow override of CSR camera transforms on init |
