### PR TITLE
Reset CSR configurator zoom on PRC sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Support `CsrRenderedInitials` mesh morphing
 * Setup `CsrRenderedInitials`
 * Add import order simple methods
-* Reset CSR configurator zoom when syncing from PRC
+* Reset CSR configurator zoom when syncing from PRC - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add `CsrTextureRenderer`
 * Add `CsrRenderedInitials`
 * Support `CsrRenderedInitials` mesh morphing
+* Reset CSR configurator zoom when syncing from PRC
 
 ### Changed
 

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -477,6 +477,9 @@ ripe.ConfiguratorCsr.prototype.syncFromPRC = async function(prcConfigurator) {
     // sets the CSR configurator visuals so it matches the PRC frame
     const frame = ripe.getFrameKey(prcConfigurator.view, prcConfigurator.position);
     await this.changeFrame(frame, { duration: 0 });
+
+    // resets camera zoom to starting value
+    this._setZoom(1);
 };
 
 ripe.ConfiguratorCsr.prototype.prcFrame = async function() {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-sdk/issues/429 |
| Dependencies | -- |
| Decisions | When syncing from PRC, it now also resets the camera zoom |
