### PR TITLE
Fix CSR debug mode not properly initializing when no CSR initials points are set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix `ConfiguratorCsr` sizes and `resize()` logic
 * Fix CSR configurator no being hidden at the demo start
 * Fix not being able to override camera transforms on CSR configurator initialization
+* Fix errors when trying to initialize CSR debug mode when no CSR initials points are set - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 
 ## [2.31.2] - 2022-06-08
 

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -1025,34 +1025,37 @@ ripe.ConfiguratorCsr.prototype._initDebug = function() {
             this.debugRefs.renderedInitials.group.add(this.debugRefs.renderedInitials.axis);
         }
 
-        // inits reference points curve
-        if (this.debugOptions.renderedInitials.line) {
-            const curve = new window.THREE.CatmullRomCurve3(
-                this.initialsRefs.renderedInitials.points,
-                false,
-                "centripetal"
-            );
-            const pointsNum = 50;
-            const linePoints = curve.getPoints(pointsNum);
-            this.debugRefs.renderedInitials.line = new window.THREE.Line(
-                new window.THREE.BufferGeometry().setFromPoints(linePoints),
-                new window.THREE.LineBasicMaterial({ color: 0x0000ff })
-            );
+        // ensures it has the minimum number of points
+        if (this.initialsRefs.renderedInitials.points > 1) {
+            // inits reference points curve
+            if (this.debugOptions.renderedInitials.line) {
+                const curve = new window.THREE.CatmullRomCurve3(
+                    this.initialsRefs.renderedInitials.points,
+                    false,
+                    "centripetal"
+                );
+                const pointsNum = 50;
+                const linePoints = curve.getPoints(pointsNum);
+                this.debugRefs.renderedInitials.line = new window.THREE.Line(
+                    new window.THREE.BufferGeometry().setFromPoints(linePoints),
+                    new window.THREE.LineBasicMaterial({ color: 0x0000ff })
+                );
 
-            this.debugRefs.renderedInitials.group.add(this.debugRefs.renderedInitials.line);
-        }
+                this.debugRefs.renderedInitials.group.add(this.debugRefs.renderedInitials.line);
+            }
 
-        // inits reference points
-        if (this.debugOptions.renderedInitials.points) {
-            const boxGeometry = new window.THREE.BoxGeometry(50, 50, 50);
-            const boxMaterial = new window.THREE.MeshBasicMaterial({ color: 0xff0000 });
+            // inits reference points
+            if (this.debugOptions.renderedInitials.points) {
+                const boxGeometry = new window.THREE.BoxGeometry(50, 50, 50);
+                const boxMaterial = new window.THREE.MeshBasicMaterial({ color: 0xff0000 });
 
-            for (const pos of this.initialsRefs.renderedInitials.points) {
-                const pointBox = new window.THREE.Mesh(boxGeometry, boxMaterial);
-                pointBox.position.copy(pos);
+                for (const pos of this.initialsRefs.renderedInitials.points) {
+                    const pointBox = new window.THREE.Mesh(boxGeometry, boxMaterial);
+                    pointBox.position.copy(pos);
 
-                this.debugRefs.renderedInitials.points.push(pointBox);
-                this.debugRefs.renderedInitials.group.add(pointBox);
+                    this.debugRefs.renderedInitials.points.push(pointBox);
+                    this.debugRefs.renderedInitials.group.add(pointBox);
+                }
             }
         }
 

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -1026,7 +1026,7 @@ ripe.ConfiguratorCsr.prototype._initDebug = function() {
         }
 
         // ensures it has the minimum number of points
-        if (this.initialsRefs.renderedInitials.points > 1) {
+        if (this.initialsRefs.renderedInitials.points.length > 1) {
             // inits reference points curve
             if (this.debugOptions.renderedInitials.line) {
                 const curve = new window.THREE.CatmullRomCurve3(


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-sdk/issues/429 |
| Dependencies | -- |
| Decisions | Fixed issue where CSR debug tools wouldn't initialize if the CSR initials were enabled and the CSR initials points array had no points |
