### PR TITLE
#429 Remove external draco loader dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add `loadFBX` and `loadEnvironment` methods to utils - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 * Add import order simple methods
 * Reset CSR configurator zoom when syncing from PRC - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
+* Add `loadMesh` method to utils - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 
 ### Changed
 
@@ -41,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Greatly improve CSR scene loading time - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 * Removed unused `format` variable from `ConfiguratorCsr` - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 * Reorder `ConfiguratorCsr` methods - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
+* Remove `dracoLoaderDecoderPath` and `dracoLoaderDecoderFallbackPath` - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
+* Remove dependency on external draco loader files - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 
 ### Fixed
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,7 +33,8 @@ const paths = {
         "node_modules/three/examples/js/loaders/GLTFLoader.js",
         "node_modules/three/examples/js/loaders/FBXLoader.js",
         "node_modules/three/examples/js/loaders/RGBELoader.js",
-        "node_modules/three/examples/js/libs/fflate.min.js"
+        "node_modules/three/examples/js/libs/fflate.min.js",
+        "node_modules/three/examples/js/libs/draco/draco_decoder.js"
     ],
     basefiles: [
         "src/js/locales/base.js",

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -594,35 +594,6 @@ ripe.ConfiguratorCsr.prototype._configuratorSize = function(size, width, height)
 };
 
 /**
- * Loads a GLTF file.
- *
- * @param {String} path Path to the file. Can be local path or an URL.
- * @returns {THREE.Mesh} The loaded model.
- *
- * @private
- */
-ripe.ConfiguratorCsr.prototype._loadMeshGLTF = async function(path) {
-    const loader = new window.THREE.GLTFLoader();
-
-    if (this.useDracoLoader) {
-        const dracoLoader = new window.THREE.DRACOLoader();
-        try {
-            dracoLoader.setDecoderPath(this.dracoLoaderDecoderPath);
-            dracoLoader.preload();
-        } catch (error) {
-            // loader fallback
-            dracoLoader.setDecoderPath(this.dracoLoaderDecoderFallbackPath);
-            dracoLoader.preload();
-        }
-        loader.setDRACOLoader(dracoLoader);
-    }
-
-    return new Promise((resolve, reject) => {
-        loader.load(path, gltf => resolve(gltf.scene));
-    });
-};
-
-/**
  * Loads a mesh.
  *
  * @param {String} path Path to the file. Can be local path or an URL.
@@ -634,7 +605,7 @@ ripe.ConfiguratorCsr.prototype._loadMeshGLTF = async function(path) {
 ripe.ConfiguratorCsr.prototype._loadMesh = async function(path, format = "gltf") {
     switch (format) {
         case "gltf":
-            return await this._loadMeshGLTF(path);
+            return await ripe.CsrUtils.loadGLTF(path, this.useDracoLoader);
         case "fbx":
             return await ripe.CsrUtils.loadFBX(path);
         default:

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -89,11 +89,6 @@ ripe.ConfiguratorCsr.prototype.init = function() {
     this.mayaScenePath = this.options.mayaScenePath || null;
     this.useDracoLoader =
         this.options.useDracoLoader !== undefined ? this.options.useDracoLoader : true;
-    this.dracoLoaderDecoderPath =
-        this.options.dracoLoaderDecoderPath || "https://www.gstatic.com/draco/v1/decoders/";
-    this.dracoLoaderDecoderFallbackPath =
-        this.options.dracoLoaderDecoderFallbackPath ||
-        "https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/js/libs/draco/";
     this.sceneEnvironmentPath =
         this.options.sceneEnvironmentPath ||
         "https://www.dl.dropboxusercontent.com/s/o0v07nn5egjrjl5/studio2.hdr";
@@ -236,14 +231,6 @@ ripe.ConfiguratorCsr.prototype.updateOptions = async function(options, update = 
         options.mayaScenePath === undefined ? this.mayaScenePath : options.mayaScenePath;
     this.useDracoLoader =
         options.useDracoLoader === undefined ? this.useDracoLoader : options.useDracoLoader;
-    this.dracoLoaderDecoderPath =
-        options.dracoLoaderDecoderPath === undefined
-            ? this.dracoLoaderDecoderPath
-            : options.dracoLoaderDecoderPath;
-    this.dracoLoaderDecoderFallbackPath =
-        options.dracoLoaderDecoderFallbackPath === undefined
-            ? this.dracoLoaderDecoderFallbackPath
-            : options.dracoLoaderDecoderFallbackPath;
     this.sceneEnvironmentPath =
         options.sceneEnvironmentPath === undefined
             ? this.sceneEnvironmentPath

--- a/src/js/visual/csr/utils.js
+++ b/src/js/visual/csr/utils.js
@@ -205,6 +205,28 @@ ripe.CsrUtils.loadFBX = async function(path) {
 };
 
 /**
+ * Loads a GLTF/GLB file.
+ *
+ * @param {String} path Path to the file. Can be local path or an URL.
+ * @param {Boolean} useDracoLoader Dictates if it should use draco loader to decode the file.
+ * @returns {THREE.Mesh} The loaded GLTF/GLB file.
+ *
+ * @private
+ */
+ripe.CsrUtils.loadGLTF = async function(path, useDracoLoader = true) {
+    const loader = new window.THREE.GLTFLoader();
+
+    if (useDracoLoader) {
+        const dracoDecoderModule = new window.DracoDecoderModule();
+        loader.setDRACOLoader(dracoDecoderModule);
+    }
+
+    return new Promise((resolve, reject) => {
+        loader.load(path, gltf => resolve(gltf.scene));
+    });
+};
+
+/**
  * Applies properties to any type of Three.js object instance.
  *
  * @param {THREE.Any} object Any type of Three.js instance that support properties.

--- a/src/js/visual/csr/utils.js
+++ b/src/js/visual/csr/utils.js
@@ -209,7 +209,7 @@ ripe.CsrUtils.loadFBX = async function(path) {
  *
  * @param {String} path Path to the file. Can be local path or an URL.
  * @param {Boolean} useDracoLoader Dictates if it should use draco loader to decode the file.
- * @returns {THREE.Mesh} The loaded GLTF/GLB file.
+ * @returns {THREE.Object3D} The loaded GLTF/GLB file.
  *
  * @private
  */

--- a/src/js/visual/csr/utils.js
+++ b/src/js/visual/csr/utils.js
@@ -210,8 +210,6 @@ ripe.CsrUtils.loadFBX = async function(path) {
  * @param {String} path Path to the file. Can be local path or an URL.
  * @param {Boolean} useDracoLoader Dictates if it should use draco loader to decode the file.
  * @returns {THREE.Object3D} The loaded GLTF/GLB file.
- *
- * @private
  */
 ripe.CsrUtils.loadGLTF = async function(path, useDracoLoader = true) {
     const loader = new window.THREE.GLTFLoader();


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-sdk/issues/429 |
| Dependencies | -- |
| Decisions | - Remove external draco loader files dependency by including draco loader with the bundle<br>- Add `loadGLTF()` method to utils |
