### PR TITLE
test: add coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
           TEST_KEY: ${{ secrets.TEST_KEY }}
           MAX_SOCKETS: ${{ secrets.MAX_SOCKETS }}
           SKIP_TEST_NOTIFY: 1
-      - run: npm test-coverage
+      - run: npm run test-coverage
         env:
           TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
           TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
@@ -58,7 +58,7 @@ jobs:
           TEST_KEY: ${{ secrets.TEST_KEY }}
           MAX_SOCKETS: ${{ secrets.MAX_SOCKETS }}
           SKIP_TEST_NOTIFY: 1
-      - run: npm test-coverage
+      - run: npm run test-coverage
         env:
           TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
           TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,13 @@ jobs:
           TEST_KEY: ${{ secrets.TEST_KEY }}
           MAX_SOCKETS: ${{ secrets.MAX_SOCKETS }}
           SKIP_TEST_NOTIFY: 1
+      - run: npm test-coverage
+        env:
+          TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
+          TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+          TEST_KEY: ${{ secrets.TEST_KEY }}
+          MAX_SOCKETS: ${{ secrets.MAX_SOCKETS }}
+          SKIP_TEST_NOTIFY: 1
   build-hosted:
     name: Build Hosted
     timeout-minutes: 10
@@ -45,6 +52,13 @@ jobs:
       - run: npm run build
       - run: npm run lint
       - run: npm test
+        env:
+          TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
+          TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+          TEST_KEY: ${{ secrets.TEST_KEY }}
+          MAX_SOCKETS: ${{ secrets.MAX_SOCKETS }}
+          SKIP_TEST_NOTIFY: 1
+      - run: npm test-coverage
         env:
           TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
           TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add import order simple methods
 * Reset CSR configurator zoom when syncing from PRC - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 * Added method for the `GET /api/info` endpoint
+* Added `test-coverage` npm script
 
 ### Changed
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -243,7 +243,10 @@ gulp.task("test", () => {
     );
 });
 
-gulp.task("test-coverage", shell.task(["nyc gulp test"]));
+gulp.task(
+    "test-coverage",
+    shell.task(["nyc --reporter=lcov --reporter=text --include=src/js gulp test"])
+);
 
 gulp.task("docs", cb => {
     const config = require("./jsdoc.json");

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,7 @@ const size = require("gulp-size");
 const babel = require("gulp-babel");
 const count = require("gulp-count");
 const mocha = require("gulp-mocha");
+const shell = require("gulp-shell");
 const jsdoc = require("gulp-jsdoc3");
 const concat = require("gulp-concat");
 const eslint = require("gulp-eslint7");
@@ -241,6 +242,8 @@ gulp.task("test", () => {
         })
     );
 });
+
+gulp.task("test-coverage", shell.task(["nyc gulp test"]));
 
 gulp.task("docs", cb => {
     const config = require("./jsdoc.json");

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
         "prettier": "prettier \"./*.{js,ts,json}\" \"./src/js/**/*.{js,ts,json}\" \"./{test,types}/**/*.{js,ts,json}\" --write",
         "pretty": "npm run prettier && npm run lint-fix",
         "test": "gulp test",
+        "test-coverage": "gulp test-coverage",
         "upgrade": "npx sort-package-json && ncu -u",
         "watch": "gulp watch"
     },
@@ -80,6 +81,7 @@
         "gulp-jsdoc3": "^3.0.0",
         "gulp-mocha": "^8.0.0",
         "gulp-replace": "^1.1.3",
+        "gulp-shell": "^0.8.0",
         "gulp-size": "^4.0.1",
         "gulp-sourcemaps": "^3.0.0",
         "gulp-terser": "^2.1.0",
@@ -89,6 +91,7 @@
         "mocha": "^8.4.0",
         "mocha-cli": "^1.0.1",
         "npm-check-updates": "^12.4.0",
+        "nyc": "^15.1.0",
         "prettier": "^2.5.1",
         "prettier-config-hive": "^0.1.7",
         "sort-package-json": "^1.54.0",


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | Added https://www.npmjs.com/package/gulp-shell and https://www.npmjs.com/package/nyc to run test coverage. Other gulp packages like gulp-istanbul are poorly maintained, not downloaded or used enough. |
| Decisions | Add test-coverage script. |
| Animated GIF | -- |
