### PR TITLE
#429 [CSR] Add tone mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added method for the `GET /api/info` endpoint
 * Added `test-coverage` npm script
 * Add `loadMesh` method to utils - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
+* Add tone mapping support to CSR - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 
 ### Changed
 

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -1061,6 +1061,10 @@ ripe.ConfiguratorCsr.prototype._initCsr = async function() {
     this.renderer.setSize(size.width, size.height);
     this.renderer.setAnimationLoop(() => this._onAnimationLoop(this));
 
+    // applies tone mapping
+    this.renderer.toneMapping = window.THREE.ACESFilmicToneMapping;
+    this.renderer.toneMappingExposure = 1;
+
     const renderer = this.element.querySelector(".renderer");
     renderer.appendChild(this.renderer.domElement);
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-sdk/issues/429 |
| Dependencies | -- |
| Decisions | Support tone mapping (the default is ACES Filmic tonemapping)  |

**None:**
<img width="316" alt="none" src="https://user-images.githubusercontent.com/22588915/198223056-292726b6-5c41-4688-9066-08819dddb1fb.png">

**Linear:**
<img width="306" alt="linear" src="https://user-images.githubusercontent.com/22588915/198223082-ba9376f6-4832-4ba2-bc78-516a5b3ff220.png">

**ACES Filmic:**
<img width="314" alt="aces" src="https://user-images.githubusercontent.com/22588915/198223068-0ddf13f6-1a2d-4abf-a12c-e35073c4460d.png">

**Reinhard:**
<img width="276" alt="reinhard" src="https://user-images.githubusercontent.com/22588915/198223129-4132e9ee-655c-4448-9355-1e29f02fb950.png">

**Cineon:**
<img width="294" alt="cineon" src="https://user-images.githubusercontent.com/22588915/198223137-e8f33eef-88c3-4056-8b91-9ee470db05de.png">
