### PR TITLE
#429 [CSR] Fix debug line points boxes wrong size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix CSR configurator no being hidden at the demo start - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 * Fix not being able to override camera transforms on CSR configurator initialization - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 * Fix errors when trying to initialize CSR debug mode when no CSR initials points are set - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
+* Fix CSR debug line points boxes wrong size - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 
 ## [2.31.2] - 2022-06-08
 

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -954,7 +954,7 @@ ripe.ConfiguratorCsr.prototype._initDebug = function() {
 
             // inits reference points
             if (this.debugOptions.renderedInitials.points) {
-                const boxGeometry = new window.THREE.BoxGeometry(50, 50, 50);
+                const boxGeometry = new window.THREE.BoxGeometry(1, 1, 1);
                 const boxMaterial = new window.THREE.MeshBasicMaterial({ color: 0xff0000 });
 
                 for (const pos of this.initialsRefs.renderedInitials.points) {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-sdk/issues/429 |
| Dependencies | -- |
| Decisions | Fix CSR debug line points boxes wrong size  |

**Before:**

https://user-images.githubusercontent.com/22588915/198253206-71997f8c-16bb-46d2-b5b0-34aea0c65763.mp4


**After:**

https://user-images.githubusercontent.com/22588915/198253215-a326cbb1-7e58-427d-b7af-629eb438a0a2.mp4

