### PR TITLE
#429 Add support for `.glb` in `loadmesh()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `test-coverage` npm script
 * Add `loadMesh` method to utils - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 * Add tone mapping support to CSR - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
+* Add support for `.glb` in `_loadMesh` - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 
 ### Changed
 

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -592,6 +592,7 @@ ripe.ConfiguratorCsr.prototype._configuratorSize = function(size, width, height)
 ripe.ConfiguratorCsr.prototype._loadMesh = async function(path, format = "gltf") {
     switch (format) {
         case "gltf":
+        case "glb":
             return await ripe.CsrUtils.loadGLTF(path, this.useDracoLoader);
         case "fbx":
             return await ripe.CsrUtils.loadFBX(path);


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-sdk/issues/429 |
| Dependencies | -- |
| Decisions | Add support for `.glb` in `loadmesh()` method |