### PR TITLE
#429 Increase number of curve types supported by `CsrRenderedInitials`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add tone mapping support to CSR - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 * Add support for `.glb` in `_loadMesh` - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 * Add `toXYZObject`, `toVector3` and `toToneMappingValue` utils - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
+* Increase number of curve types supported by `CsrRenderedInitials` - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 
 ### Changed
 

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -941,7 +941,8 @@ ripe.ConfiguratorCsr.prototype._initDebug = function() {
                 const curve = new window.THREE.CatmullRomCurve3(
                     this.initialsRefs.renderedInitials.points,
                     false,
-                    "centripetal"
+                    this.initialsRefs.renderedInitials.curveOptions.type,
+                    this.initialsRefs.renderedInitials.curveOptions.tension
                 );
                 const pointsNum = 50;
                 const linePoints = curve.getPoints(pointsNum);

--- a/src/js/visual/csr/rendered-initials.js
+++ b/src/js/visual/csr/rendered-initials.js
@@ -75,6 +75,11 @@ ripe.CsrRenderedInitials = function(
     };
 
     // unpacks the CSR Initials Renderer options
+    const curveOpts = options.curveOptions || {};
+    this.curveOptions = {
+        type: curveOpts.type !== undefined ? curveOpts.type : "centripetal",
+        tension: curveOpts.tension !== undefined ? curveOpts.tension : 0.5
+    };
     const textOpts = options.textOptions || {};
     this.textOptions = {
         font: textOpts.font !== undefined ? textOpts.font : "Arial",
@@ -512,7 +517,12 @@ ripe.CsrRenderedInitials.prototype._buildGeometry = function() {
  */
 ripe.CsrRenderedInitials.prototype._morphPlaneGeometry = function(geometry, points) {
     // creates a curve based on the reference points
-    const curve = new window.THREE.CatmullRomCurve3(points, false, "centripetal");
+    const curve = new window.THREE.CatmullRomCurve3(
+        points,
+        false,
+        this.curveOptions.type,
+        this.curveOptions.tension
+    );
 
     // calculates the curve width
     const curveWidth = Math.round(curve.getLength());


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-sdk/issues/429 |
| Dependencies | -- |
| Decisions |  Increase number of curve types supported by `CsrRenderedInitials`. The types supported are `centripetal`, `chordal` and `catmullrom` which are part of the family of Catmull–Rom splines. |

#### Examples of curve with points `[[-8, 8, 8], [0, 8, 8], [8, 8, 8], [8, 8, -8]]`

**`catmullrom` type with `tension = 0` example:**
<img width="411" alt="catmull_1_tension_0" src="https://user-images.githubusercontent.com/22588915/199463772-2f634810-0f01-4f35-b117-2ab42de9dba6.png">

**`catmullrom` type with `tension = 1` example:**
<img width="413" alt="catmull_2_tension_1" src="https://user-images.githubusercontent.com/22588915/199463777-cab20308-1d4d-486d-8e52-e10d0c44410f.png">
<img width="452" alt="catmull_3_tension_1" src="https://user-images.githubusercontent.com/22588915/199463780-ac85df4d-32b7-46ff-964c-bdfb08742490.png">


**`chordal` type example:**
<img width="440" alt="centripetal_1" src="https://user-images.githubusercontent.com/22588915/199463821-690d50ba-6617-48bc-85b7-bb65bc5610f3.png">
<img width="411" alt="centripetal_2" src="https://user-images.githubusercontent.com/22588915/199463824-46e8920e-3d74-4a2f-b71f-53fc6741fc18.png">


**`chordal` type example:**
<img width="414" alt="chordal_1" src="https://user-images.githubusercontent.com/22588915/199463843-de16b123-274e-428c-a11d-fa94c02b2353.png">
<img width="400" alt="chordal_2" src="https://user-images.githubusercontent.com/22588915/199463846-3934813d-0580-40f9-b1df-4b72b28ac82a.png">

