### PR TITLE
fix: no mask buffers if useMasks false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Fixed creation and usage of mask buffers according to the use mask option
+
 ## [2.32.0] - 2022-11-10
 
 ### Added

--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -399,30 +399,35 @@ ripe.ConfiguratorPrc.prototype.resize = async function(size, width, height) {
     }
 
     const area = this.element.querySelector(".area");
-    const frontMask = this.element.querySelector(".front-mask");
     const back = this.element.querySelector(".back");
-    const mask = this.element.querySelector(".mask");
     area.width = width * this.pixelRatio;
     area.height = height * this.pixelRatio;
     area.style.width = width + "px";
     area.style.height = height + "px";
-    frontMask.width = width;
-    frontMask.height = height;
-    frontMask.style.width = width + "px";
-    frontMask.style.height = height + "px";
-    frontMask.style.marginLeft = `-${String(width)}px`;
     back.width = width * this.pixelRatio;
     back.height = height * this.pixelRatio;
     back.style.width = width + "px";
     back.style.height = height + "px";
     back.style.marginLeft = `-${String(width)}px`;
-    mask.width = width;
-    mask.height = height;
-    mask.style.width = width + "px";
-    mask.style.height = height + "px";
     this.currentSize = size;
     this.currentWidth = width;
     this.currentHeight = height;
+
+    if (this.useMasks) {
+        const frontMask = this.element.querySelector(".front-mask");
+        frontMask.width = width;
+        frontMask.height = height;
+        frontMask.style.width = width + "px";
+        frontMask.style.height = height + "px";
+        frontMask.style.marginLeft = `-${String(width)}px`;
+
+        const mask = this.element.querySelector(".mask");
+        mask.width = width;
+        mask.height = height;
+        mask.style.width = width + "px";
+        mask.style.height = height + "px";
+    }
+
     await this.update(
         {},
         {
@@ -997,11 +1002,6 @@ ripe.ConfiguratorPrc.prototype._initLayout = function() {
     context.globalCompositeOperation = "multiply";
     this.element.appendChild(area);
 
-    // adds the front mask element to the element,
-    // this will be used to highlight parts
-    const frontMask = ripe.createElement("img", "front-mask");
-    this.element.appendChild(frontMask);
-
     // creates the back canvas and adds it to the element,
     // placing it on top of the area canvas
     const back = ripe.createElement("canvas", "back");
@@ -1018,15 +1018,21 @@ ripe.ConfiguratorPrc.prototype._initLayout = function() {
     // temporarily store the images of the product's frames
     const framesBuffer = ripe.createElement("div", "frames-buffer");
 
-    // creates a masksBuffer element that will be used to store the continuous
-    // mask images to be used during highlight and select operation
-    const masksBuffer = ripe.createElement("div", "masks-buffer");
+    if (this.useMasks) {
+        // adds the front mask element to the element,
+        // this will be used to highlight parts
+        const frontMask = ripe.createElement("img", "front-mask");
+        this.element.appendChild(frontMask);
 
-    // adds both buffer elements (frames and masks) to the base elements
-    // they are going to be used as placeholders for the "img" elements
-    // that are going to be loaded with the images
+        // creates a masksBuffer element that will be used to store the continuous
+        // mask images to be used during highlight and select operation
+        const masksBuffer = ripe.createElement("div", "masks-buffer");
+        this.element.appendChild(masksBuffer);
+    }
+
+    // adds the frames buffer to the base elements to be used as placeholders 
+    // for the "img" elements that are going to be loaded with the images
     this.element.appendChild(framesBuffer);
-    this.element.appendChild(masksBuffer);
 
     // set the size of area, frontMask, back and mask
     this.resize();

--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -1030,7 +1030,7 @@ ripe.ConfiguratorPrc.prototype._initLayout = function() {
         this.element.appendChild(masksBuffer);
     }
 
-    // adds the frames buffer to the base elements to be used as placeholders 
+    // adds the frames buffer to the base elements to be used as placeholders
     // for the "img" elements that are going to be loaded with the images
     this.element.appendChild(framesBuffer);
 
@@ -1070,13 +1070,13 @@ ripe.ConfiguratorPrc.prototype._populateBuffers = function() {
     if (!this.element) return;
 
     let buffer = null;
-    
+
     const framesBuffer = this.element.getElementsByClassName("frames-buffer");
     for (let index = 0; index < framesBuffer.length; index++) {
         buffer = framesBuffer[index];
         this._populateBuffer(buffer);
     }
-    
+
     if (this.useMasks) {
         const masksBuffer = this.element.getElementsByClassName("masks-buffer");
         for (let index = 0; index < masksBuffer.length; index++) {
@@ -1236,7 +1236,7 @@ ripe.ConfiguratorPrc.prototype._loadFrame = async function(view, position, optio
     let image = framesBuffer.querySelector(`img[data-frame='${String(frame)}']`);
     const front = area.querySelector(`img[data-frame='${String(frame)}']`);
     image = image || front;
-    
+
     // triggers the async loading of the "master" mask for the current
     // frame, this should imply some level of cache usage
     if (this.useMasks) {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-sdk/issues/446 |
| Dependencies | -- |
| Decisions | If masks are turned off, we cant create the mask buffers (image elements) because they will load the masks anyways even if disabled. |
| Animated GIF | -- |
