### PR TITLE
fix: load mask only if using masks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* If no masks are to be used, create the mask buffers but don't load them, avoiding network requests - [#446](https://github.com/ripe-tech/ripe-sdk/issues/446)
+
 ## [2.32.0] - 2022-11-10
 
 ### Added

--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -1240,7 +1240,7 @@ ripe.ConfiguratorPrc.prototype._loadFrame = async function(view, position, optio
 
     // triggers the async loading of the "master" mask for the current
     // frame, this should imply some level of cache usage
-    this._loadMask(maskImage, view, position, options);
+    if (this.useMasks) this._loadMask(maskImage, view, position, options);
 
     // apply pixel ratio to image dimensions so that the image obtained
     // reflects the target pixel density

--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -1238,8 +1238,9 @@ ripe.ConfiguratorPrc.prototype._loadFrame = async function(view, position, optio
         throw new RangeError("Frame " + frame + " is not supported");
     }
 
-    // triggers the async loading of the "master" mask for the current
-    // frame, this should imply some level of cache usage
+    // in case masks are set to be used, triggers the async loading of 
+    // the "master" mask for the current frame, this should imply some level
+    // of cache usage
     if (this.useMasks) this._loadMask(maskImage, view, position, options);
 
     // apply pixel ratio to image dimensions so that the image obtained

--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -1238,7 +1238,7 @@ ripe.ConfiguratorPrc.prototype._loadFrame = async function(view, position, optio
         throw new RangeError("Frame " + frame + " is not supported");
     }
 
-    // in case masks are set to be used, triggers the async loading of 
+    // in case masks are set to be used, triggers the async loading of
     // the "master" mask for the current frame, this should imply some level
     // of cache usage
     if (this.useMasks) this._loadMask(maskImage, view, position, options);


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-sdk/issues/446 |
| Dependencies | -- |
| Decisions | If masks are not to be used, just avoid loading them but create the buffers anyways. |
| Animated GIF | **Before**<br> ![image](https://user-images.githubusercontent.com/16060539/203519409-ffcafdfb-3ca0-48ab-9193-e290f34f0787.png) **After**<br>  ![image](https://user-images.githubusercontent.com/16060539/203519673-bbc916f4-ec15-4746-9349-9f0515870867.png)|

For example, using the following test script:

```js
configuratorPrc = ripe.bindConfigurator(element, {
    duration: 250,
    useMasks: true,
    view: bestFace(result)
});
configuratorPrc.isFirst = true;

setTimeout(() => {
    configuratorPrc.updateOptions({ useMasks: false });
}, 6000);
```

I was able to start out with masks and 6 seconds later have them disappear and requests stopped being made:

![disablemasks](https://user-images.githubusercontent.com/16060539/203521361-d89652ce-4630-4fef-b306-b23d32d231fe.gif)
