### PR TITLE
#271 Add quantity param to import order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Add `quantity` param to `_importOrder` method - [ripe-pulse/#271](https://github.com/ripe-tech/ripe-pulse/issues/271)
 
 ### Changed
 

--- a/src/js/api/order.js
+++ b/src/js/api/order.js
@@ -2377,6 +2377,7 @@ ripe.Ripe.prototype._getOrderImageURL = function(number, key, options) {
 ripe.Ripe.prototype._importOrder = function(ffOrderId, options = {}) {
     const dku = options.dku === undefined ? null : options.dku;
     const type = options.type === undefined ? null : options.type;
+    const quantity = options.quantity === undefined ? null : options.quantity;
     const brand = options.brand === undefined ? this.brand : options.brand;
     const factory = options.factory === undefined ? null : options.factory;
     const model = options.model === undefined ? this.model : options.model;
@@ -2437,6 +2438,7 @@ ripe.Ripe.prototype._importOrder = function(ffOrderId, options = {}) {
     if (Object.keys(contents).length > 0) params.contents = JSON.stringify(contents);
     if (dku) params.dku = dku;
     if (type) params.type = type;
+    if (quantity) params.quantity = quantity;
     if (country) params.country = country;
     if (currency) params.currency = currency;
     if (meta) params.meta = meta;

--- a/test/js/api/order.js
+++ b/test/js/api/order.js
@@ -209,6 +209,32 @@ describe("OrderAPI", function() {
 
             await remote.deleteOrderP(result.number);
         });
+
+        it("should be able to set the quantity", async () => {
+            let result = null;
+
+            const remote = ripe.RipeAPI({ url: config.TEST_URL });
+            const ffOrderId = uuid.v4();
+
+            result = await remote.authAdminP(config.TEST_USERNAME, config.TEST_PASSWORD);
+
+            assert.strictEqual(result.username, config.TEST_USERNAME);
+            assert.notStrictEqual(typeof result.sid, undefined);
+
+            result = await remote.importOrderP(ffOrderId, {
+                type: "buildless",
+                brand: "dummy",
+                model: "dummy",
+                quantity: 22
+            });
+            assert.strictEqual(result.ff_order_id, ffOrderId);
+            assert.strictEqual(result.type, "buildless");
+            assert.strictEqual(result.brand, "dummy");
+            assert.strictEqual(result.shoe, "dummy");
+            assert.strictEqual(result.quantity, 22);
+
+            await remote.deleteOrderP(result.number);
+        });
     });
 
     describe("#preCustomization()", function() {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-pulse/issues/271 |
| Decisions | - Add `quantity` param to `_importOrder` method |

