### PR TITLE
#429 Support `curve_type` and `curve_tension` config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Add `quantity` param to `_importOrder` method - [ripe-pulse/#271](https://github.com/ripe-tech/ripe-pulse/issues/271)
+* Support `curve_type` and `curve_tension` config values - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 
 ### Changed
 

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -1441,6 +1441,11 @@ ripe.ConfiguratorCsr.prototype._onPostConfig = async function(self, config) {
             : undefined;
         initialsOptions.scale = initials3d.scale;
 
+        // unpacks initials curve options
+        const curveOptions = {};
+        curveOptions.type = initials3d.curve_type;
+        curveOptions.tension = initials3d.curve_tension;
+
         // unpacks initials text options
         const textOptions = {};
         textOptions.font = initials.font_family;
@@ -1469,6 +1474,7 @@ ripe.ConfiguratorCsr.prototype._onPostConfig = async function(self, config) {
         meshOptions.heightSegments = initials3d.mesh_height_segments;
 
         initialsOptions.options = {
+            curveOptions: curveOptions,
             textOptions: textOptions,
             materialOptions: materialOptions,
             meshOptions: meshOptions


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-sdk/issues/429 |
| Dependencies | https://github.com/ripe-tech/ripe-docs/pull/631 |
| Decisions |  Improved manipulation of initials canvas curvature by supporting loading `curve_type` and `curve_tension` from config. Related: https://github.com/ripe-tech/ripe-sdk/pull/442 |
