### PR TITLE
#429 Support metallic, normal and roughness textures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Support `curve_type` and `curve_tension` config values - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 * Add `get3dSceneEnvironmentUrl`, `getInitials3dBaseTextureUrl` and `getInitials3dDisplacementTextureUrl` methods - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 * Set CSR mesh url default variant value to `"$base"` - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
+* Add `getInitials3dMetallicTextureUrl `, `getInitials3dNormalTextureUrl` and `getInitials3dRoughnessTextureUrl` methods - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
+* Support metallic, normal and roughness textures - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 
 ### Changed
 
 * Use config in CSR - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 * Change default test timeout to 60 seconds
 * Revert ripe-sdk-demo variant value to `""` - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
+* Generalize `CsrRenderedInitials` textures logic - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Support `curve_type` and `curve_tension` config values - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 * Add `get3dSceneEnvironmentUrl`, `getInitials3dBaseTextureUrl` and `getInitials3dDisplacementTextureUrl` methods - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 * Set CSR mesh url default variant value to `"$base"` - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
-* Add `getInitials3dMetallicTextureUrl `, `getInitials3dNormalTextureUrl` and `getInitials3dRoughnessTextureUrl` methods - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
+* Add `getTextureMapUrl ` method - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 * Support metallic, normal and roughness textures - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 
 ### Changed

--- a/src/js/api/brand.js
+++ b/src/js/api/brand.js
@@ -136,7 +136,6 @@ ripe.Ripe.prototype.get3dSceneEnvironmentUrl = function(options) {
     return "https://www.dl.dropboxusercontent.com/s/o0v07nn5egjrjl5/studio2.hdr";
 };
 
-
 /**
  * Returns the URL for the texture of the specified texture map type.
  *

--- a/src/js/api/brand.js
+++ b/src/js/api/brand.js
@@ -145,7 +145,7 @@ ripe.Ripe.prototype.get3dSceneEnvironmentUrl = function(options) {
  *  - 'brand' - The brand of the model.
  *  - 'model' - The name of the model.
  *  - 'version' - The version of the build, defaults to latest.
- * @returns {String} The URL of the initials base texture.
+ * @returns {String} The URL of the specified initials texture.
  */
 ripe.Ripe.prototype.getTextureMapUrl = function(map, options) {
     return null;

--- a/src/js/api/brand.js
+++ b/src/js/api/brand.js
@@ -138,7 +138,7 @@ ripe.Ripe.prototype.get3dSceneEnvironmentUrl = function(options) {
 
 
 /**
- * Returns the URL for the specified texture map type.
+ * Returns the URL for the texture of the specified texture map type.
  *
  * @param {String} map The texture map type that the should be url should point to.
  * @param {Object} options A map with options, such as:

--- a/src/js/api/brand.js
+++ b/src/js/api/brand.js
@@ -136,68 +136,18 @@ ripe.Ripe.prototype.get3dSceneEnvironmentUrl = function(options) {
     return "https://www.dl.dropboxusercontent.com/s/o0v07nn5egjrjl5/studio2.hdr";
 };
 
+
 /**
- * Returns the URL for the base texture for the initials mesh.
+ * Returns the URL for the specified texture map type.
  *
+ * @param {String} map The texture map type that the should be url should point to.
  * @param {Object} options A map with options, such as:
  *  - 'brand' - The brand of the model.
  *  - 'model' - The name of the model.
  *  - 'version' - The version of the build, defaults to latest.
  * @returns {String} The URL of the initials base texture.
  */
-ripe.Ripe.prototype.getInitials3dBaseTextureUrl = function(options) {
-    return null;
-};
-
-/**
- * Returns the URL for the displacement texture for the initials mesh.
- *
- * @param {Object} options A map with options, such as:
- *  - 'brand' - The brand of the model.
- *  - 'model' - The name of the model.
- *  - 'version' - The version of the build, defaults to latest.
- * @returns {String} The URL of the initials displacement texture.
- */
-ripe.Ripe.prototype.getInitials3dDisplacementTextureUrl = function(options) {
-    return null;
-};
-
-/**
- * Returns the URL for the metallic texture for the initials mesh.
- *
- * @param {Object} options A map with options, such as:
- *  - 'brand' - The brand of the model.
- *  - 'model' - The name of the model.
- *  - 'version' - The version of the build, defaults to latest.
- * @returns {String} The URL of the initials metallic texture.
- */
-ripe.Ripe.prototype.getInitials3dMetallicTextureUrl = function(options) {
-    return null;
-};
-
-/**
- * Returns the URL for the normal texture for the initials mesh.
- *
- * @param {Object} options A map with options, such as:
- *  - 'brand' - The brand of the model.
- *  - 'model' - The name of the model.
- *  - 'version' - The version of the build, defaults to latest.
- * @returns {String} The URL of the initials normal texture.
- */
-ripe.Ripe.prototype.getInitials3dNormalTextureUrl = function(options) {
-    return null;
-};
-
-/**
- * Returns the URL for the roughness texture for the initials mesh.
- *
- * @param {Object} options A map with options, such as:
- *  - 'brand' - The brand of the model.
- *  - 'model' - The name of the model.
- *  - 'version' - The version of the build, defaults to latest.
- * @returns {String} The URL of the initials roughness texture.
- */
-ripe.Ripe.prototype.getInitials3dRoughnessTextureUrl = function(options) {
+ripe.Ripe.prototype.getTextureMapUrl = function(map, options) {
     return null;
 };
 

--- a/src/js/api/brand.js
+++ b/src/js/api/brand.js
@@ -133,7 +133,6 @@ ripe.Ripe.prototype.getMeshUrl = function(options) {
  * @returns {String} The URL of the environment for the 3D scene.
  */
 ripe.Ripe.prototype.get3dSceneEnvironmentUrl = function(options) {
-    options = this._getMeshOptions(options);
     return "https://www.dl.dropboxusercontent.com/s/o0v07nn5egjrjl5/studio2.hdr";
 };
 
@@ -147,7 +146,6 @@ ripe.Ripe.prototype.get3dSceneEnvironmentUrl = function(options) {
  * @returns {String} The URL of the initials base texture.
  */
 ripe.Ripe.prototype.getInitials3dBaseTextureUrl = function(options) {
-    options = this._getMeshOptions(options);
     return null;
 };
 
@@ -161,7 +159,6 @@ ripe.Ripe.prototype.getInitials3dBaseTextureUrl = function(options) {
  * @returns {String} The URL of the initials displacement texture.
  */
 ripe.Ripe.prototype.getInitials3dDisplacementTextureUrl = function(options) {
-    options = this._getMeshOptions(options);
     return null;
 };
 
@@ -175,7 +172,6 @@ ripe.Ripe.prototype.getInitials3dDisplacementTextureUrl = function(options) {
  * @returns {String} The URL of the initials metallic texture.
  */
 ripe.Ripe.prototype.getInitials3dMetallicTextureUrl = function(options) {
-    options = this._getMeshOptions(options);
     return null;
 };
 
@@ -189,7 +185,6 @@ ripe.Ripe.prototype.getInitials3dMetallicTextureUrl = function(options) {
  * @returns {String} The URL of the initials normal texture.
  */
 ripe.Ripe.prototype.getInitials3dNormalTextureUrl = function(options) {
-    options = this._getMeshOptions(options);
     return null;
 };
 
@@ -203,7 +198,6 @@ ripe.Ripe.prototype.getInitials3dNormalTextureUrl = function(options) {
  * @returns {String} The URL of the initials roughness texture.
  */
 ripe.Ripe.prototype.getInitials3dRoughnessTextureUrl = function(options) {
-    options = this._getMeshOptions(options);
     return null;
 };
 

--- a/src/js/api/brand.js
+++ b/src/js/api/brand.js
@@ -166,6 +166,48 @@ ripe.Ripe.prototype.getInitials3dDisplacementTextureUrl = function(options) {
 };
 
 /**
+ * Returns the URL for the metallic texture for the initials mesh.
+ *
+ * @param {Object} options A map with options, such as:
+ *  - 'brand' - The brand of the model.
+ *  - 'model' - The name of the model.
+ *  - 'version' - The version of the build, defaults to latest.
+ * @returns {String} The URL of the initials metallic texture.
+ */
+ripe.Ripe.prototype.getInitials3dMetallicTextureUrl = function(options) {
+    options = this._getMeshOptions(options);
+    return null;
+};
+
+/**
+ * Returns the URL for the normal texture for the initials mesh.
+ *
+ * @param {Object} options A map with options, such as:
+ *  - 'brand' - The brand of the model.
+ *  - 'model' - The name of the model.
+ *  - 'version' - The version of the build, defaults to latest.
+ * @returns {String} The URL of the initials normal texture.
+ */
+ripe.Ripe.prototype.getInitials3dNormalTextureUrl = function(options) {
+    options = this._getMeshOptions(options);
+    return null;
+};
+
+/**
+ * Returns the URL for the roughness texture for the initials mesh.
+ *
+ * @param {Object} options A map with options, such as:
+ *  - 'brand' - The brand of the model.
+ *  - 'model' - The name of the model.
+ *  - 'version' - The version of the build, defaults to latest.
+ * @returns {String} The URL of the initials roughness texture.
+ */
+ripe.Ripe.prototype.getInitials3dRoughnessTextureUrl = function(options) {
+    options = this._getMeshOptions(options);
+    return null;
+};
+
+/**
  * Returns the configuration information of a specific brand and model.
  * If no model is provided then returns the information of the owner's current model.
  *

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -1400,11 +1400,11 @@ ripe.ConfiguratorCsr.prototype._onPostConfig = async function(self, config) {
         let normalTexturePath = null;
         let roughnessTexturePath = null;
         if (initialsEnabled) {
-            baseTexturePath = this.owner.getInitials3dBaseTextureUrl();
-            displacementTexturePath = this.owner.getInitials3dDisplacementTextureUrl();
-            metallicTexturePath = this.owner.getInitials3dMetallicTextureUrl();
-            normalTexturePath = this.owner.getInitials3dNormalTextureUrl();
-            roughnessTexturePath = this.owner.getInitials3dRoughnessTextureUrl();
+            baseTexturePath = this.owner.getTextureMapUrl("pattern");
+            displacementTexturePath = this.owner.getTextureMapUrl("displacement");
+            metallicTexturePath = this.owner.getTextureMapUrl("metallic");
+            normalTexturePath = this.owner.getTextureMapUrl("normal");
+            roughnessTexturePath = this.owner.getTextureMapUrl("roughness");
         }
 
         // loads assets

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -111,7 +111,10 @@ ripe.ConfiguratorCsr.prototype.init = function() {
         renderedInitials: null,
         mesh: null,
         baseTexture: null,
-        displacementTexture: null
+        displacementTexture: null,
+        metallicTexture: null,
+        normalTexture: null,
+        roughnessTexture: null
     };
 
     // CSR debug variables
@@ -816,6 +819,24 @@ ripe.ConfiguratorCsr.prototype._initCsrRenderedInitials = function() {
             this.initialsOptions.options.displacementTextureOptions
         );
     }
+    if (this.initialsRefs.metallicTexture) {
+        this.initialsRefs.renderedInitials.setMetallicTexture(
+            this.initialsRefs.metallicTexture,
+            this.initialsOptions.options.metallicTextureOptions
+        );
+    }
+    if (this.initialsRefs.normalTexture) {
+        this.initialsRefs.renderedInitials.setNormalTexture(
+            this.initialsRefs.normalTexture,
+            this.initialsOptions.options.normalTextureOptions
+        );
+    }
+    if (this.initialsRefs.roughnessTexture) {
+        this.initialsRefs.renderedInitials.setRoughnessTexture(
+            this.initialsRefs.roughnessTexture,
+            this.initialsOptions.options.roughnessTextureOptions
+        );
+    }
 
     // uses rendered initials mesh
     this.initialsRefs.mesh = this.initialsRefs.renderedInitials.getMesh();
@@ -863,6 +884,9 @@ ripe.ConfiguratorCsr.prototype._unloadCsrRenderedInitialsResources = function() 
     // cleanup loaded textures
     if (this.initialsRefs.baseTexture) this.initialsRefs.baseTexture.dispose();
     if (this.initialsRefs.displacementTexture) this.initialsRefs.displacementTexture.dispose();
+    if (this.initialsRefs.metallicTexture) this.initialsRefs.metallicTexture.dispose();
+    if (this.initialsRefs.normalTexture) this.initialsRefs.normalTexture.dispose();
+    if (this.initialsRefs.roughnessTexture) this.initialsRefs.roughnessTexture.dispose();
 
     // free all resources used
     if (this.initialsRefs.renderedInitials) this.initialsRefs.renderedInitials.destroy();
@@ -870,7 +894,10 @@ ripe.ConfiguratorCsr.prototype._unloadCsrRenderedInitialsResources = function() 
         renderedInitials: null,
         mesh: null,
         baseTexture: null,
-        displacementTexture: null
+        displacementTexture: null,
+        metallicTexture: null,
+        normalTexture: null,
+        roughnessTexture: null
     };
 };
 
@@ -1364,9 +1391,15 @@ ripe.ConfiguratorCsr.prototype._onPostConfig = async function(self, config) {
         // checks if it should load assets used by the initials
         let baseTexturePath = null;
         let displacementTexturePath = null;
+        let metallicTexturePath = null;
+        let normalTexturePath = null;
+        let roughnessTexturePath = null;
         if (initialsEnabled) {
             baseTexturePath = this.owner.getInitials3dBaseTextureUrl();
             displacementTexturePath = this.owner.getInitials3dDisplacementTextureUrl();
+            metallicTexturePath = this.owner.getInitials3dMettalicTextureUrl();
+            normalTexturePath = this.owner.getInitials3dNormalTextureUrl();
+            roughnessTexturePath = this.owner.getInitials3dRoughnessTextureUrl();
         }
 
         // loads assets
@@ -1374,12 +1407,18 @@ ripe.ConfiguratorCsr.prototype._onPostConfig = async function(self, config) {
             this.mesh,
             this.environmentTexture,
             this.initialsRefs.baseTexture,
-            this.initialsRefs.displacementTexture
+            this.initialsRefs.displacementTexture,
+            this.initialsRefs.metallicTexture,
+            this.initialsRefs.normalTexture,
+            this.initialsRefs.roughnessTexture
         ] = await Promise.all([
             this._loadMesh(meshPath, meshFormat),
             envPath ? ripe.CsrUtils.loadEnvironment(envPath, envFormat) : null,
             baseTexturePath ? ripe.CsrUtils.loadTexture(baseTexturePath) : null,
-            displacementTexturePath ? ripe.CsrUtils.loadTexture(displacementTexturePath) : null
+            displacementTexturePath ? ripe.CsrUtils.loadTexture(displacementTexturePath) : null,
+            metallicTexturePath  ? ripe.CsrUtils.loadTexture(metallicTexturePath) : null,
+            normalTexturePath  ? ripe.CsrUtils.loadTexture(normalTexturePath) : null,
+            roughnessTexturePath  ? ripe.CsrUtils.loadTexture(roughnessTexturePath) : null
         ]);
 
         // gets the 3d set from the config

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -808,31 +808,36 @@ ripe.ConfiguratorCsr.prototype._initCsrRenderedInitials = function() {
 
     // apply textures to initials
     if (this.initialsRefs.baseTexture) {
-        this.initialsRefs.renderedInitials.setBaseTexture(
+        this.initialsRefs.renderedInitials.setTexture(
+            "base",
             this.initialsRefs.baseTexture,
             this.initialsOptions.options.baseTextureOptions
         );
     }
     if (this.initialsRefs.displacementTexture) {
-        this.initialsRefs.renderedInitials.setDisplacementTexture(
+        this.initialsRefs.renderedInitials.setTexture(
+            "displacement",
             this.initialsRefs.displacementTexture,
             this.initialsOptions.options.displacementTextureOptions
         );
     }
     if (this.initialsRefs.metallicTexture) {
-        this.initialsRefs.renderedInitials.setMetallicTexture(
+        this.initialsRefs.renderedInitials.setTexture(
+            "metallic",
             this.initialsRefs.metallicTexture,
             this.initialsOptions.options.metallicTextureOptions
         );
     }
     if (this.initialsRefs.normalTexture) {
-        this.initialsRefs.renderedInitials.setNormalTexture(
+        this.initialsRefs.renderedInitials.setTexture(
+            "normal",
             this.initialsRefs.normalTexture,
             this.initialsOptions.options.normalTextureOptions
         );
     }
     if (this.initialsRefs.roughnessTexture) {
-        this.initialsRefs.renderedInitials.setRoughnessTexture(
+        this.initialsRefs.renderedInitials.setTexture(
+            "roughness",
             this.initialsRefs.roughnessTexture,
             this.initialsOptions.options.roughnessTextureOptions
         );
@@ -1397,7 +1402,7 @@ ripe.ConfiguratorCsr.prototype._onPostConfig = async function(self, config) {
         if (initialsEnabled) {
             baseTexturePath = this.owner.getInitials3dBaseTextureUrl();
             displacementTexturePath = this.owner.getInitials3dDisplacementTextureUrl();
-            metallicTexturePath = this.owner.getInitials3dMettalicTextureUrl();
+            metallicTexturePath = this.owner.getInitials3dMetallicTextureUrl();
             normalTexturePath = this.owner.getInitials3dNormalTextureUrl();
             roughnessTexturePath = this.owner.getInitials3dRoughnessTextureUrl();
         }
@@ -1416,9 +1421,9 @@ ripe.ConfiguratorCsr.prototype._onPostConfig = async function(self, config) {
             envPath ? ripe.CsrUtils.loadEnvironment(envPath, envFormat) : null,
             baseTexturePath ? ripe.CsrUtils.loadTexture(baseTexturePath) : null,
             displacementTexturePath ? ripe.CsrUtils.loadTexture(displacementTexturePath) : null,
-            metallicTexturePath  ? ripe.CsrUtils.loadTexture(metallicTexturePath) : null,
-            normalTexturePath  ? ripe.CsrUtils.loadTexture(normalTexturePath) : null,
-            roughnessTexturePath  ? ripe.CsrUtils.loadTexture(roughnessTexturePath) : null
+            metallicTexturePath ? ripe.CsrUtils.loadTexture(metallicTexturePath) : null,
+            normalTexturePath ? ripe.CsrUtils.loadTexture(normalTexturePath) : null,
+            roughnessTexturePath ? ripe.CsrUtils.loadTexture(roughnessTexturePath) : null
         ]);
 
         // gets the 3d set from the config

--- a/src/js/visual/csr/rendered-initials.js
+++ b/src/js/visual/csr/rendered-initials.js
@@ -129,13 +129,12 @@ ripe.CsrRenderedInitials = function(
         widthSegments: meshOpts.widthSegments !== undefined ? meshOpts.widthSegments : 1000,
         heightSegments: meshOpts.heightSegments !== undefined ? meshOpts.heightSegments : 100
     };
-    const baseTextureOpts = options.baseTextureOptions || {};
-    this[this._textureOptionsKey("base")] = { ...DEFAULT_TEXTURE_SETTINGS, ...baseTextureOpts };
-    const displacementTextureOpts = options.displacementTextureOptions || {};
-    this[this._textureOptionsKey("displacement")] = {
-        ...DEFAULT_TEXTURE_SETTINGS,
-        ...displacementTextureOpts
-    };
+    SUPPORTED_TEXTURE_TYPES.forEach(type => {
+        const key = this._textureOptionsKey(type);
+        const textureTypeOptions = options[key] || {};
+        this[key] = { ...DEFAULT_TEXTURE_SETTINGS, ...textureTypeOptions };
+        console.log("type", type, "___", "key", key);
+    });
 
     // sets the CSR Initials Renderer size
     this.setSize(width, height);

--- a/src/js/visual/csr/rendered-initials.js
+++ b/src/js/visual/csr/rendered-initials.js
@@ -133,7 +133,6 @@ ripe.CsrRenderedInitials = function(
         const key = this._textureOptionsKey(type);
         const textureTypeOptions = options[key] || {};
         this[key] = { ...DEFAULT_TEXTURE_SETTINGS, ...textureTypeOptions };
-        console.log("type", type, "___", "key", key);
     });
 
     // sets the CSR Initials Renderer size

--- a/src/js/visual/csr/rendered-initials.js
+++ b/src/js/visual/csr/rendered-initials.js
@@ -336,7 +336,6 @@ ripe.CsrRenderedInitials.prototype.updateOptions = function(options = {}) {
         this.meshOptions = { ...this.meshOptions, ...options.meshOptions };
         updateMesh = true;
     }
-
     SUPPORTED_TEXTURE_TYPES.forEach(type => {
         const key = this._textureOptionsKey(type);
         if (options[key]) {

--- a/src/js/visual/csr/rendered-initials.js
+++ b/src/js/visual/csr/rendered-initials.js
@@ -235,10 +235,12 @@ ripe.CsrRenderedInitials.prototype.getMesh = function() {
 
 /**
  * Sets the texture specified by it's type. The supported types are the following:
- * - base: This texture is the diffuse pattern that is applied to
- * the initials characters.
- * - displacement: This texture is the height map pattern that is applied to
- * the height map texture of the initials characters.
+ * - base: This texture is the diffuse pattern that is applied to the initials characters.
+ * - displacement: This texture is the height map pattern that is applied to the initials
+ * characters.
+ * - metallic: This texture is the metallic texture that is applied to the initials characters.
+ * - normal: This texture is the normal map pattern that is applied to the initials characters.
+ * - roughness: This texture is the roughness texture that is applied to the initials characters.
  *
  * @param {String} type The texture type name.
  * @param {THREE.Texture} texture The texture to set for the specified type.


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-sdk/issues/429 |
| Dependencies | -- |
| Decisions | - Add `getTextureMapUrl` method<br>- Support metallic, normal and roughness textures<br>- Generalize `CsrRenderedInitials` textures logic |
