### PR TITLE
#429 Increase control points debug boxes size

### DIFF
--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -957,7 +957,7 @@ ripe.ConfiguratorCsr.prototype._initDebug = function() {
 
             // inits reference points
             if (this.debugOptions.renderedInitials.points) {
-                const boxGeometry = new window.THREE.BoxGeometry(50, 50, 50);
+                const boxGeometry = new window.THREE.BoxGeometry(30, 30, 30);
                 const boxMaterial = new window.THREE.MeshBasicMaterial({ color: 0xff0000 });
 
                 for (const pos of this.initialsRefs.renderedInitials.points) {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-sdk/issues/429 |
| Dependencies | -- |
| Decisions | Fix CSR initials control points debug boxes being too small |
| Screenshots | **Before:**<br>![image](https://user-images.githubusercontent.com/22588915/210245737-8c6f1c22-783f-4276-a880-58f974fd55f5.png)<br>**After:**![image](https://user-images.githubusercontent.com/22588915/210245064-e084ec2c-18c4-4500-83cb-3a1b44591feb.png) |
