### PR TITLE
version: 2.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+*
+
+### Changed
+
+*
+
+### Fixed
+
+*
+
+## [2.34.0] - 2023-01-02
+
+### Added
+
 * Support `curve_type` and `curve_tension` config values - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 * Add `get3dSceneEnvironmentUrl`, `getInitials3dBaseTextureUrl` and `getInitials3dDisplacementTextureUrl` methods - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 * Set CSR mesh url default variant value to `"$base"` - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ripe-sdk",
-    "version": "2.33.0",
+    "version": "2.34.0",
     "description": "The public SDK for RIPE Core",
     "keywords": [
         "js",

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -16,7 +16,7 @@ if (
  * The version of the RIPE SDK currently in load, should
  * be in sync with the package information.
  */
-ripe.VERSION = "2.33.0";
+ripe.VERSION = "2.34.0";
 
 /**
  * Object that contains global (static) information to be used by


### PR DESCRIPTION
### Added

* Support `curve_type` and `curve_tension` config values - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
* Add `get3dSceneEnvironmentUrl`, `getInitials3dBaseTextureUrl` and `getInitials3dDisplacementTextureUrl` methods - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
* Set CSR mesh url default variant value to `"$base"` - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)

### Changed
* Use config in CSR - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
* Change default test timeout to 60 seconds
* Revert ripe-sdk-demo variant value to `""` - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)

### Fixed
* If no masks are to be used, create the mask buffers but don't load them, avoiding network requests - [#446](https://github.com/ripe-tech/ripe-sdk/issues/446)
* Fix CSR initials control points debug boxes being too small - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
* Set optional status change params in the request params