### PR TITLE
#429 Support loading of external fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Support loading of external fonts - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 
 ### Changed
 

--- a/src/js/api/brand.js
+++ b/src/js/api/brand.js
@@ -752,6 +752,9 @@ ripe.Ripe.prototype._getFontOptions = function(options = {}) {
     if (variant !== undefined && variant !== null) {
         params.variant = variant;
     }
+    if (options.weight !== undefined && options.weight !== null) {
+        params.weight = options.weight;
+    }
     return Object.assign(options, {
         url: url,
         method: "GET",

--- a/src/js/api/brand.js
+++ b/src/js/api/brand.js
@@ -124,6 +124,22 @@ ripe.Ripe.prototype.getMeshUrl = function(options) {
 };
 
 /**
+ * Returns the URL where the font can be retrieved.
+ *
+ * @param {Object} options A map with options, such as:
+ *  - 'brand' - The brand of the model.
+ *  - 'model' - The name of the model.
+ *  - 'version' - The version of the build, defaults to latest.
+ * @returns {String} The URL of the specified initials texture.
+ */
+ripe.Ripe.prototype.getFontUrl = function(name, format, options) {
+    options = this._getFontOptions(options);
+    format = format || "ttf";
+    const url = options.url + `/${name}.${format}`
+    return url + "?" + this._buildQuery(options.params);
+};
+
+/**
  * Returns the URL for the environment file of the 3D scene.
  *
  * @param {Object} options A map with options, such as:
@@ -707,6 +723,28 @@ ripe.Ripe.prototype._getMeshOptions = function(options = {}) {
     const version = options.version === undefined ? this.version : options.version;
     const variant = options.variant === undefined ? this.variant : options.variant;
     const url = `${this.url}brands/${brand}/models/${model}/mesh`;
+    const params = {};
+    if (version !== undefined && version !== null) {
+        params.version = version;
+    }
+    if (variant !== undefined && variant !== null) {
+        params.variant = variant;
+    }
+    return Object.assign(options, {
+        url: url,
+        method: "GET",
+        params: params
+    });
+};
+
+/**
+ * @ignore
+ */
+ripe.Ripe.prototype._getFontOptions = function(options = {}) {
+    const brand = options.brand === undefined ? this.brand : options.brand;
+    const version = options.version === undefined ? this.version : options.version;
+    const variant = options.variant === undefined ? this.variant : options.variant;
+    const url = `${this.url}brands/${brand}/fonts`;
     const params = {};
     if (version !== undefined && version !== null) {
         params.version = version;

--- a/src/js/api/brand.js
+++ b/src/js/api/brand.js
@@ -135,7 +135,7 @@ ripe.Ripe.prototype.getMeshUrl = function(options) {
 ripe.Ripe.prototype.getFontUrl = function(name, format, options) {
     options = this._getFontOptions(options);
     format = format || "ttf";
-    const url = options.url + `/${name}.${format}`
+    const url = options.url + `/${name}.${format}`;
     return url + "?" + this._buildQuery(options.params);
 };
 

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -550,6 +550,15 @@ ripe.ConfiguratorCsr.prototype._configuratorSize = function(size, width, height)
     };
 };
 
+ripe.ConfiguratorCsr.prototype._loadExternalFont = async function(name, url) {
+    if (!name) throw new Error("Name is required");
+    if (!url) throw new Error("URL is required");
+
+    const font = new FontFace(name, `url(${url})`);
+    await font.load();
+    document.fonts.add(font);
+};
+
 /**
  * Loads a mesh.
  *
@@ -1394,6 +1403,8 @@ ripe.ConfiguratorCsr.prototype._onPostConfig = async function(self, config) {
         const initialsEnabled = this.owner.hasPersonalization();
 
         // checks if it should load assets used by the initials
+        const fontName = "Test Font"; // TODO Should be equal to the font_family from build
+        const fontUrl = ""; // TODO handle the font issue
         let baseTexturePath = null;
         let displacementTexturePath = null;
         let metallicTexturePath = null;
@@ -1410,6 +1421,7 @@ ripe.ConfiguratorCsr.prototype._onPostConfig = async function(self, config) {
         // loads assets
         [
             this.mesh,
+            ,
             this.environmentTexture,
             this.initialsRefs.baseTexture,
             this.initialsRefs.displacementTexture,
@@ -1418,6 +1430,7 @@ ripe.ConfiguratorCsr.prototype._onPostConfig = async function(self, config) {
             this.initialsRefs.roughnessTexture
         ] = await Promise.all([
             this._loadMesh(meshPath, meshFormat),
+            fontUrl ? this._loadExternalFont(fontName, fontUrl) : null,
             envPath ? ripe.CsrUtils.loadEnvironment(envPath, envFormat) : null,
             baseTexturePath ? ripe.CsrUtils.loadTexture(baseTexturePath) : null,
             displacementTexturePath ? ripe.CsrUtils.loadTexture(displacementTexturePath) : null,

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -567,6 +567,14 @@ ripe.ConfiguratorCsr.prototype._configuratorSize = function(size, width, height)
     };
 };
 
+/**
+ * Loads a font from a URL and adds it to the document font set.
+ *
+ * @param {Number} name The name to give to the font.
+ * @param {Number} url The URL for the font file.
+ *
+ * @private
+ */
 ripe.ConfiguratorCsr.prototype._loadExternalFont = async function(name, url) {
     if (!name) throw new Error("Name is required");
     if (!url) throw new Error("URL is required");

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -1404,7 +1404,7 @@ ripe.ConfiguratorCsr.prototype._onPostConfig = async function(self, config) {
 
         // checks if it should load assets used by the initials
         const fontName = "Test Font"; // TODO Should be equal to the font_family from build
-        const fontUrl = ""; // TODO handle the font issue
+        const fontUrl = "https://www.dl.dropboxusercontent.com/s/5s6gt2wbg2ic1km/DINCondensed-Ripple.ttf"; // TODO handle the font issue
         let baseTexturePath = null;
         let displacementTexturePath = null;
         let metallicTexturePath = null;

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -1413,9 +1413,11 @@ ripe.ConfiguratorCsr.prototype._onPostConfig = async function(self, config) {
         let normalTexturePath = null;
         let roughnessTexturePath = null;
         if (initialsEnabled) {
-            fontUrl = this.owner.getFontUrl(initials.font_family, "ttf", {
-                weight: initials.font_weight
-            });
+            fontUrl = initials.font_family
+                ? this.owner.getFontUrl(initials.font_family, "ttf", {
+                      weight: initials.font_weight
+                  })
+                : null;
             baseTexturePath = this.owner.getTextureMapUrl("pattern");
             displacementTexturePath = this.owner.getTextureMapUrl("displacement");
             metallicTexturePath = this.owner.getTextureMapUrl("metallic");

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -1402,15 +1402,20 @@ ripe.ConfiguratorCsr.prototype._onPostConfig = async function(self, config) {
         // checks if initials are enabled
         const initialsEnabled = this.owner.hasPersonalization();
 
+        // gets the initials set from the config
+        const initials = config.initials || {};
+
         // checks if it should load assets used by the initials
-        const fontName = "Test Font"; // TODO Should be equal to the font_family from build
-        const fontUrl = this.owner.getFontUrl(fontName, "ttf");
+        let fontUrl = null;
         let baseTexturePath = null;
         let displacementTexturePath = null;
         let metallicTexturePath = null;
         let normalTexturePath = null;
         let roughnessTexturePath = null;
         if (initialsEnabled) {
+            fontUrl = this.owner.getFontUrl(initials.font_family, "ttf", {
+                weight: initials.font_weight
+            });
             baseTexturePath = this.owner.getTextureMapUrl("pattern");
             displacementTexturePath = this.owner.getTextureMapUrl("displacement");
             metallicTexturePath = this.owner.getTextureMapUrl("metallic");
@@ -1430,7 +1435,7 @@ ripe.ConfiguratorCsr.prototype._onPostConfig = async function(self, config) {
             this.initialsRefs.roughnessTexture
         ] = await Promise.all([
             this._loadMesh(meshPath, meshFormat),
-            fontUrl ? this._loadExternalFont(fontName, fontUrl) : null,
+            fontUrl ? this._loadExternalFont(initials.font_family, fontUrl) : null,
             envPath ? ripe.CsrUtils.loadEnvironment(envPath, envFormat) : null,
             baseTexturePath ? ripe.CsrUtils.loadTexture(baseTexturePath) : null,
             displacementTexturePath ? ripe.CsrUtils.loadTexture(displacementTexturePath) : null,
@@ -1480,8 +1485,7 @@ ripe.ConfiguratorCsr.prototype._onPostConfig = async function(self, config) {
             }
         }
 
-        // gets the initials and initials.3d set from the config
-        const initials = config.initials || {};
+        // gets the initials.3d set from the config
         const initials3d = initials["3d"] || {};
 
         // unpacks initials options

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -1404,7 +1404,7 @@ ripe.ConfiguratorCsr.prototype._onPostConfig = async function(self, config) {
 
         // checks if it should load assets used by the initials
         const fontName = "Test Font"; // TODO Should be equal to the font_family from build
-        const fontUrl = "https://www.dl.dropboxusercontent.com/s/5s6gt2wbg2ic1km/DINCondensed-Ripple.ttf"; // TODO handle the font issue
+        const fontUrl = this.owner.getFontUrl(fontName, "ttf");
         let baseTexturePath = null;
         let displacementTexturePath = null;
         let metallicTexturePath = null;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-sdk/issues/429 |
| Dependencies | <del>https://github.com/ripe-tech/ripe-sdk/pull/455</del> |
| Decisions | Add `getFontUrl()` and `_getFontOptions()` methods<br> Load font based on config |
