### PR TITLE
#429 Support post render callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Add support for param `imagesDefault` - [ripe-core/#4778](https://github.com/ripe-tech/ripe-core/issues/4778)
+* Add support for post render callback - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 
 ### Changed
 

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -1209,6 +1209,7 @@ ripe.ConfiguratorCsr.prototype._render = function() {
     if (!this.camera) throw new Error("Camera not initiated");
     if (!this.renderer) throw new Error("Renderer not initiated");
     this.renderer.render(this.scene, this.camera);
+    this._onPostRender();
 };
 
 /**
@@ -1280,9 +1281,6 @@ ripe.ConfiguratorCsr.prototype._onAnimationLoop = function(self) {
 
     // renders a frame
     self._render();
-
-    // immediately calls post render after the render has finished
-    self._onPostRender();
 };
 
 /**

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -91,6 +91,7 @@ ripe.ConfiguratorCsr.prototype.init = function() {
     this.animations = [];
     this.isChangeFrameAnimationRunning = false;
     this._pendingOps = [];
+    this._postRenderCallback = null;
 
     // CSR variables
     this.rendererOptions = null;

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -528,6 +528,14 @@ ripe.ConfiguratorCsr.prototype.prcFrame = async function() {
     return `side-${positionRounded}`;
 };
 
+ripe.ConfiguratorCsr.prototype.subscribePostRender = function(callback) {
+    this._postRenderCallback = callback;
+};
+
+ripe.ConfiguratorCsr.prototype.unsubscribePostRender = function() {
+    this._postRenderCallback = null;
+};
+
 /**
  * Tries to obtain the best possible size for the configurator
  * defaulting to the client with of the element as fallback.
@@ -1271,7 +1279,17 @@ ripe.ConfiguratorCsr.prototype._onAnimationLoop = function(self) {
 
     // renders a frame
     self._render();
+
+    // immediately calls post render after the render has finished
+    self._onPostRender();
 };
+
+/**
+ * @ignore
+ */
+ripe.ConfiguratorCsr.prototype._onPostRender = function() {
+    if(this._postRenderCallback) this._postRenderCallback();
+}
 
 /**
  * @ignore

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -539,7 +539,7 @@ ripe.ConfiguratorCsr.prototype.setPostRender = function(callback) {
 };
 
 /**
- * Clears the the post render callback registry.
+ * Clears the post render callback registry.
  */
 ripe.ConfiguratorCsr.prototype.unsetPostRender = function() {
     this._postRenderCallback = null;

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -540,9 +540,7 @@ ripe.ConfiguratorCsr.prototype.setPostRender = function(callback) {
 
 
 /**
- * Unsets the callback function for the post render call.
- *
- * @param {Function} callback The function to be called.
+ * Clears the the post render callback registry.
  */
 ripe.ConfiguratorCsr.prototype.unsetPostRender = function() {
     this._postRenderCallback = null;

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -538,7 +538,6 @@ ripe.ConfiguratorCsr.prototype.setPostRender = function(callback) {
     this._postRenderCallback = callback;
 };
 
-
 /**
  * Clears the the post render callback registry.
  */
@@ -1296,8 +1295,8 @@ ripe.ConfiguratorCsr.prototype._onAnimationLoop = function(self) {
  * @ignore
  */
 ripe.ConfiguratorCsr.prototype._onPostRender = function() {
-    if(this._postRenderCallback) this._postRenderCallback();
-}
+    if (this._postRenderCallback) this._postRenderCallback();
+};
 
 /**
  * @ignore

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -529,10 +529,21 @@ ripe.ConfiguratorCsr.prototype.prcFrame = async function() {
     return `side-${positionRounded}`;
 };
 
+/**
+ * Sets the callback function for the post render call.
+ *
+ * @param {Function} callback The function to be called.
+ */
 ripe.ConfiguratorCsr.prototype.subscribePostRender = function(callback) {
     this._postRenderCallback = callback;
 };
 
+
+/**
+ * Unsets the callback function for the post render call.
+ *
+ * @param {Function} callback The function to be called.
+ */
 ripe.ConfiguratorCsr.prototype.unsubscribePostRender = function() {
     this._postRenderCallback = null;
 };

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -534,7 +534,7 @@ ripe.ConfiguratorCsr.prototype.prcFrame = async function() {
  *
  * @param {Function} callback The function to be called.
  */
-ripe.ConfiguratorCsr.prototype.subscribePostRender = function(callback) {
+ripe.ConfiguratorCsr.prototype.setPostRender = function(callback) {
     this._postRenderCallback = callback;
 };
 
@@ -544,7 +544,7 @@ ripe.ConfiguratorCsr.prototype.subscribePostRender = function(callback) {
  *
  * @param {Function} callback The function to be called.
  */
-ripe.ConfiguratorCsr.prototype.unsubscribePostRender = function() {
+ripe.ConfiguratorCsr.prototype.unsetPostRender = function() {
     this._postRenderCallback = null;
 };
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-sdk/issues/429 |
| Dependencies | -- |
| Decisions | Allows setting a callback to be ran immediately after the render. This is useful for cases where, for example, we want immediate access to the renderer frame buffer |
