### PR TITLE
#416 Auth callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Add support for post render callback - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 * Add support for param `imagesDefault` - [ripe-core/#4778](https://github.com/ripe-tech/ripe-core/issues/4778)
-* Add support for param `authCallback` - [ripe-robin-revamp/#416](https://github.com/ripe-tech/ripe-robin-revamp/issues/416)
+* Add support for global option `authCallback` and improve overall behavior, allowing one request authentication - [ripe-robin-revamp/#416](https://github.com/ripe-tech/ripe-robin-revamp/issues/416)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Add support for param `imagesDefault` - [ripe-core/#4778](https://github.com/ripe-tech/ripe-core/issues/4778)
+* Add support for param `authCallback` - [ripe-robin-revamp/#416](https://github.com/ripe-tech/ripe-robin-revamp/issues/416)
 
 ### Changed
 
-*
+* Returning `authCallback` when requests fails authentication to allow one auth call. - [ripe-robin-revamp/#416](https://github.com/ripe-tech/ripe-robin-revamp/issues/416)
 
 ### Fixed
 

--- a/src/js/api/order.js
+++ b/src/js/api/order.js
@@ -2456,7 +2456,8 @@ ripe.Ripe.prototype._importOrder = function(ffOrderId, options = {}) {
     const notes = options.notes === undefined ? null : options.notes;
     const images = options.images === undefined ? null : options.images;
     const safe = options.safe === undefined ? null : options.safe ? "1" : "0";
-    const imagesDefault = options.imagesDefault === undefined ? null : options.imagesDefault ? 1 : 0;
+    const imagesDefault =
+        options.imagesDefault === undefined ? null : options.imagesDefault ? 1 : 0;
 
     const url = `${this.url}orders/import`;
     const contents = {};

--- a/src/js/base/api.js
+++ b/src/js/base/api.js
@@ -419,11 +419,11 @@ ripe.Ripe.prototype._cacheURL = function(url, options, callback) {
         // authentication one and there are retries left then tries
         // the authentication callback and retries the request
         if (isAuthError && retries > 0) {
-            authCallback(() => {
+            return authCallback(extraParams => {
                 options.retries = retries - 1;
-                this._cacheURL(url, options, callback);
+                options.params = { ...options.params, ...extraParams };
+                return this._cacheURL(url, options, callback);
             });
-            return;
         }
 
         // in case the result of the request is valid and caching

--- a/src/js/base/api.js
+++ b/src/js/base/api.js
@@ -1351,6 +1351,8 @@ ripe.Ripe.prototype._build = function(options) {
         (this.sid === undefined || this.sid === null) &&
         (this.key === undefined || this.key === null)
     ) {
+        const authCallback = options.authCallback || this.authCallback;
+        if (authCallback) authCallback();
         throw new Error("Authorization requested but none is available");
     }
     options.url = url;

--- a/src/js/base/api.js
+++ b/src/js/base/api.js
@@ -1349,10 +1349,10 @@ ripe.Ripe.prototype._build = function(options) {
     if (
         auth &&
         (this.sid === undefined || this.sid === null) &&
-        (this.key === undefined || this.key === null)
+        (this.key === undefined || this.key === null) &&
+        (options.authCallback === undefined || options.authCallback === null) &&
+        (this.authCallback === undefined || this.authCallback === null)
     ) {
-        const authCallback = options.authCallback || this.authCallback;
-        if (authCallback) authCallback();
         throw new Error("Authorization requested but none is available");
     }
     options.url = url;

--- a/src/js/base/api.js
+++ b/src/js/base/api.js
@@ -382,8 +382,9 @@ ripe.Ripe.prototype._cacheURL = function(url, options, callback) {
     cached = cached && !options.force && ["GET"].indexOf(options.method || "GET") !== -1;
 
     // determines the correct callback to be called once an auth
-    // related problem occurs, defaulting to the base one in case
-    // none is passed via options object
+    // related problem occurs, fallsback to global `authCallback`
+    // and finally to the base one in case none is passed
+    // via options object or global SDK options
     const authCallback = options.authCallback || this.authCallback || this._authCallback;
 
     // determines if the cache entry should be invalidated before
@@ -419,6 +420,9 @@ ripe.Ripe.prototype._cacheURL = function(url, options, callback) {
         // authentication one and there are retries left then tries
         // the authentication callback and retries the request
         if (isAuthError && retries > 0) {
+            // returns `authCallback` allowing the authentication
+            // to be done inside the callback and to return the
+            // request result after a successful auth
             return authCallback(extraParams => {
                 options.retries = retries - 1;
                 options.params = { ...options.params, ...extraParams };

--- a/src/js/base/api.js
+++ b/src/js/base/api.js
@@ -384,7 +384,7 @@ ripe.Ripe.prototype._cacheURL = function(url, options, callback) {
     // determines the correct callback to be called once an auth
     // related problem occurs, defaulting to the base one in case
     // none is passed via options object
-    const authCallback = options.authCallback || this._authCallback;
+    const authCallback = options.authCallback || this.authCallback || this._authCallback;
 
     // determines if the cache entry should be invalidated before
     // making the request, it should only be invalidate in case the

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -690,6 +690,7 @@ ripe.Ripe.prototype.setOptions = function(options = {}) {
             ? true
             : this.options.useInitialsBuilderLogic;
     this.composeLogic = this.options.composeLogic === undefined ? false : this.options.composeLogic;
+    this.authCallback = this.options.authCallback === undefined ? null : this.options.authCallback;
 
     // in case the requested format is the "dynamic" lossless one
     // tries to find the best lossless image format taking into account


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-robin-revamp/issues/416 |
| Decisions | - Add `authCallback` to global options and improved overall behavior - returning the callback to allow one call authentication. |
