### PR TITLE
#429 Use enriched initials config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add support for post render callback - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 * Add support for param `imagesDefault` - [ripe-core/#4778](https://github.com/ripe-tech/ripe-core/issues/4778)
 * Add support for global option `authCallback` and improve overall behavior, allowing one request authentication - [ripe-robin-revamp/#416](https://github.com/ripe-tech/ripe-robin-revamp/issues/416)
+* Add `getInitialsConfig` , `getInitialsConfigP` and `_getInitialsConfigOptions` methods - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
+* Load enriched initials config in CSR - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
 
 ### Changed
 

--- a/src/js/api/brand.js
+++ b/src/js/api/brand.js
@@ -194,6 +194,45 @@ ripe.Ripe.prototype.getConfigP = function(options) {
 };
 
 /**
+ * Returns the initials configuration information of a specific brand and model.
+ * If no model is provided then returns the information of the owner's current model.
+ *
+ * @param {Object} options A map with options, such as:
+ *  - 'brand' - The brand of the model.
+ *  - 'model' - The name of the model.
+ *  - 'version' - The version of the build, defaults to latest.
+ *  - 'profiles' - The list of initials profiles.
+ * @param {Function} callback Function with the result of the request.
+ * @returns {XMLHttpRequest} The model's initials configuration data.
+ */
+ripe.Ripe.prototype.getInitialsConfig = function(options, callback) {
+    callback = typeof options === "function" ? options : callback;
+    options = typeof options === "function" || options === undefined ? {} : options;
+    options = this._getInitialsConfigOptions(options);
+    options = this._build(options);
+    return this._cacheURL(options.url, options, callback);
+};
+
+/**
+ * Returns the initials configuration information of a specific brand and model.
+ * If no model is provided then returns the information of the owner's current model.
+ *
+ * @param {Object} options A map with options, such as:
+ *  - 'brand' - The brand of the model.
+ *  - 'model' - The name of the model.
+ *  - 'version' - The version of the build, defaults to latest.
+ *  - 'profiles' - The list of initials profiles.
+ * @returns {Promise} The model's configuration data.
+ */
+ripe.Ripe.prototype.getInitialsConfigP = function(options) {
+    return new Promise((resolve, reject) => {
+        this.getInitialsConfig(options, (result, isValid, request) => {
+            isValid ? resolve(result) : reject(new ripe.RemoteError(request, null, result));
+        });
+    });
+};
+
+/**
  * Returns the default customization of a specific brand or model. If no model is provided
  * then returns the defaults of the owner's current model.
  *
@@ -739,6 +778,29 @@ ripe.Ripe.prototype._getConfigOptions = function(options = {}) {
     }
     if (options.filter !== undefined && options.filter !== null) {
         params.filter = options.filter ? "1" : "0";
+    }
+    return Object.assign(options, {
+        url: url,
+        method: "GET",
+        params: params
+    });
+};
+
+/**
+ * @ignore
+ */
+ripe.Ripe.prototype._getInitialsConfigOptions = function(options = {}) {
+    const brand = options.brand === undefined ? this.brand : options.brand;
+    const model = options.model === undefined ? this.model : options.model;
+    const version = options.version === undefined ? this.version : options.version;
+    const profiles = options.profiles === undefined ? [] : options.profiles;
+    const url = `${this.url}brands/${brand}/models/${model}/config/initials`;
+    const params = {};
+    if (version !== undefined && version !== null) {
+        params.version = version;
+    }
+    if (profiles !== undefined && profiles !== null) {
+        params.profiles = profiles;
     }
     return Object.assign(options, {
         url: url,

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -1418,6 +1418,9 @@ ripe.ConfiguratorCsr.prototype._onPostConfig = async function(self, config) {
         // checks if initials are enabled
         const initialsEnabled = this.owner.hasPersonalization();
 
+        // gets the initials config
+        const initials = await this.owner.getInitialsConfigP();
+
         // checks if it should load assets used by the initials
         let baseTexturePath = null;
         let displacementTexturePath = null;
@@ -1492,8 +1495,7 @@ ripe.ConfiguratorCsr.prototype._onPostConfig = async function(self, config) {
             }
         }
 
-        // gets the initials and initials.3d set from the config
-        const initials = config.initials || {};
+        // gets the initials.3d set from the config
         const initials3d = initials["3d"] || {};
 
         // unpacks initials options


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-sdk/issues/429 |
| Dependencies | -- |
| Decisions | Add `getInitialsConfig `, `getInitialsConfigP()` and `_getInitialsConfigOptions ()` methods<br> Load enriched initials config |
