### PR TITLE
#481 Fix meshes compressed with Draco not loading properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Improve CSR loading methodology - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
+* Reuse Draco loader instance - [#481](https://github.com/ripe-tech/ripe-sdk/issues/481)
+* Removed `draco_decoder.js` dependency - [#481](https://github.com/ripe-tech/ripe-sdk/issues/481)
 
 ### Fixed
 
-*
+* Fix meshes compressed with Draco not loading properly - [#481](https://github.com/ripe-tech/ripe-sdk/issues/481)
 
 ## [2.36.0] - 2023-02-10
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,8 +34,7 @@ const paths = {
         "node_modules/three/examples/js/loaders/GLTFLoader.js",
         "node_modules/three/examples/js/loaders/FBXLoader.js",
         "node_modules/three/examples/js/loaders/RGBELoader.js",
-        "node_modules/three/examples/js/libs/fflate.min.js",
-        "node_modules/three/examples/js/libs/draco/draco_decoder.js"
+        "node_modules/three/examples/js/libs/fflate.min.js"
     ],
     basefiles: [
         "src/js/locales/base.js",

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -95,11 +95,11 @@ ripe.ConfiguratorCsr.prototype.init = function() {
 
     // CSR variables
     this.rendererOptions = null;
-    this.useDracoLoader = null;
     this.cameraOptions = null;
     this.zoomOptions = null;
     this.enabledInitials = null;
     this.initialsOptions = null;
+    this.dracoLoader = null;
     this.renderer = null;
     this.camera = null;
     this.scene = null;
@@ -597,7 +597,7 @@ ripe.ConfiguratorCsr.prototype._loadMesh = async function(path, format = "gltf")
     switch (format) {
         case "gltf":
         case "glb":
-            return await ripe.CsrUtils.loadGLTF(path, this.useDracoLoader);
+            return await ripe.CsrUtils.loadGLTF(path, this.dracoLoader);
         case "fbx":
             return await ripe.CsrUtils.loadFBX(path);
         default:
@@ -1362,11 +1362,14 @@ ripe.ConfiguratorCsr.prototype._loadCsrAssets = async function(
 ) {
     const variant = this.owner.variant || "$base";
 
-    // computes mesh URL
+    // loads mesh info
     const meshesConfig = config.meshes || {};
     const meshInfo = meshesConfig[variant] || {};
     const meshUrl = this.owner.getMeshUrl({ variant: variant });
     const meshFormat = meshInfo.format || "glb";
+    
+    // loads needed loaders for the meshes
+    this.dracoLoader = ripe.CsrUtils.loadDracoLoader();
 
     // computes environment file URL
     const envUrl = this.owner.get3dSceneEnvironmentUrl();
@@ -1457,7 +1460,6 @@ ripe.ConfiguratorCsr.prototype._initConfigDefaults = function(options) {
         toneMappingExposure:
             rendererOpts.toneMappingExposure !== undefined ? rendererOpts.toneMappingExposure : 1
     };
-    this.useDracoLoader = options.useDracoLoader !== undefined ? options.useDracoLoader : true;
     const cameraOpts = options.cameraOptions || {};
     this.cameraOptions = {
         fov: cameraOpts.fov !== undefined ? cameraOpts.fov : 24.678,
@@ -1715,7 +1717,6 @@ ripe.ConfiguratorCsr.prototype._onPostConfig = async function(self, config) {
         // can properly be built
         this._initConfigDefaults({
             rendererOptions: sceneOptions.rendererOptions || {},
-            useDracoLoader: true,
             cameraOptions: sceneOptions.cameraOptions || {},
             zoomOptions: sceneOptions.zoomOptions || {},
             enabledInitials: initialsEnabled,

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -1367,7 +1367,7 @@ ripe.ConfiguratorCsr.prototype._loadCsrAssets = async function(
     const meshInfo = meshesConfig[variant] || {};
     const meshUrl = this.owner.getMeshUrl({ variant: variant });
     const meshFormat = meshInfo.format || "glb";
-    
+
     // loads needed loaders for the meshes
     this.dracoLoader = ripe.CsrUtils.loadDracoLoader();
 

--- a/src/js/visual/csr/utils.js
+++ b/src/js/visual/csr/utils.js
@@ -238,7 +238,8 @@ ripe.CsrUtils.loadDracoLoader = function() {
         dracoLoader.preload();
     } catch (error) {
         // loader fallback
-        const fallbackURL = "https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/js/libs/draco/";
+        const fallbackURL =
+            "https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/js/libs/draco/";
         dracoLoader.setDecoderPath(fallbackURL);
         dracoLoader.preload();
     }
@@ -301,8 +302,8 @@ ripe.CsrUtils.loadFBX = async function(path) {
  */
 ripe.CsrUtils.loadGLTF = async function(path, dracoLoader = null) {
     const loader = new window.THREE.GLTFLoader();
-    if(dracoLoader) loader.setDRACOLoader(dracoLoader);
-    
+    if (dracoLoader) loader.setDRACOLoader(dracoLoader);
+
     return new Promise((resolve, reject) => {
         loader.load(path, gltf => resolve(gltf.scene));
     });

--- a/src/js/visual/csr/utils.js
+++ b/src/js/visual/csr/utils.js
@@ -279,14 +279,10 @@ ripe.CsrUtils.loadFBX = async function(path) {
  * @param {Boolean} useDracoLoader Dictates if it should use draco loader to decode the file.
  * @returns {THREE.Object3D} The loaded GLTF/GLB file.
  */
-ripe.CsrUtils.loadGLTF = async function(path, useDracoLoader = true) {
+ripe.CsrUtils.loadGLTF = async function(path, dracoLoader = null) {
     const loader = new window.THREE.GLTFLoader();
-
-    if (useDracoLoader) {
-        const dracoDecoderModule = new window.DracoDecoderModule();
-        loader.setDRACOLoader(dracoDecoderModule);
-    }
-
+    if(dracoLoader) loader.setDRACOLoader(dracoLoader);
+    
     return new Promise((resolve, reject) => {
         loader.load(path, gltf => resolve(gltf.scene));
     });

--- a/src/js/visual/csr/utils.js
+++ b/src/js/visual/csr/utils.js
@@ -297,7 +297,7 @@ ripe.CsrUtils.loadFBX = async function(path) {
  * Loads a GLTF/GLB file.
  *
  * @param {String} path Path to the file. Can be local path or an URL.
- * @param {Boolean} useDracoLoader Dictates if it should use draco loader to decode the file.
+ * @param {THREE.DRACOLoader} dracoLoader A Draco loader instance.
  * @returns {THREE.Object3D} The loaded GLTF/GLB file.
  */
 ripe.CsrUtils.loadGLTF = async function(path, dracoLoader = null) {

--- a/src/js/visual/csr/utils.js
+++ b/src/js/visual/csr/utils.js
@@ -239,7 +239,7 @@ ripe.CsrUtils.loadDracoLoader = function() {
     } catch (error) {
         // loader fallback
         const fallbackURL =
-            "https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/js/libs/draco/";
+            "https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/jsm/libs/draco/";
         dracoLoader.setDecoderPath(fallbackURL);
         dracoLoader.preload();
     }

--- a/src/js/visual/csr/utils.js
+++ b/src/js/visual/csr/utils.js
@@ -238,9 +238,9 @@ ripe.CsrUtils.loadDracoLoader = function() {
         dracoLoader.preload();
     } catch (error) {
         // loader fallback
-        const fallbackURL =
-            "https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/jsm/libs/draco/";
-        dracoLoader.setDecoderPath(fallbackURL);
+        dracoLoader.setDecoderPath(
+            "https://raw.githubusercontent.com/google/draco/master/javascript/"
+        );
         dracoLoader.preload();
     }
 

--- a/src/js/visual/csr/utils.js
+++ b/src/js/visual/csr/utils.js
@@ -227,6 +227,26 @@ ripe.CsrUtils.shortestRotationRad = function(start, end) {
 };
 
 /**
+ * Loads a Draco Loader instance.
+ *
+ * @returns {THREE.DRACOLoader} The loaded instance of a Draco Loader.
+ */
+ripe.CsrUtils.loadDracoLoader = function() {
+    const dracoLoader = new window.THREE.DRACOLoader();
+    try {
+        dracoLoader.setDecoderPath("https://www.gstatic.com/draco/v1/decoders/");
+        dracoLoader.preload();
+    } catch (error) {
+        // loader fallback
+        const fallbackURL = "https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/js/libs/draco/";
+        dracoLoader.setDecoderPath(fallbackURL);
+        dracoLoader.preload();
+    }
+
+    return dracoLoader;
+};
+
+/**
  * Loads a texture from a file.
  *
  * @param {String} path Path to the file. Can be local path or an URL.


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-sdk/issues/481 |
| Dependencies | |
| Decisions | - Fix meshes compressed with Draco not loading properly<br>- Improve performance by reusing Draco loader instance instead of loading it each time a mesh is loaded<br>- Removed `draco_decoder.js` dependency as it's not needed to be bundled anymore |

