### PR TITLE
#1098 Add params to `ready` event in configurator csr and prc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Add `post_config` event to configurator csr `_postConfig` - [#1098](https://github.com/ripe-tech/ripe-white/issues/1098)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Add id to `init` to better distinguish configurator `ready` events - [ripe-white/#1098](https://github.com/ripe-tech/ripe-white/issues/1098)
+* Add `id` and `origin` to `ready` event params to distinguish events from configurator prc and csr - [ripe-white/#1098](https://github.com/ripe-tech/ripe-white/issues/1098)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Add `post_config` event to configurator csr `_postConfig` - [ripe-white/#1098](https://github.com/ripe-tech/ripe-white/issues/1098)
+* Add id to `ready` event after configurator `_postConfig` to allow the use of a loader - [ripe-white/#1098](https://github.com/ripe-tech/ripe-white/issues/1098)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Add id to `ready` event after configurator `_postConfig` to allow the use of a loader - [ripe-white/#1098](https://github.com/ripe-tech/ripe-white/issues/1098)
+* Add id to `init` to better distinguish configurator `ready` events - [ripe-white/#1098](https://github.com/ripe-tech/ripe-white/issues/1098)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Add `post_config` event to configurator csr `_postConfig` - [#1098](https://github.com/ripe-tech/ripe-white/issues/1098)
+* Add `post_config` event to configurator csr `_postConfig` - [ripe-white/#1098](https://github.com/ripe-tech/ripe-white/issues/1098)
 
 ### Changed
 

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -58,6 +58,7 @@ ripe.ConfiguratorCsr.prototype.init = function() {
     ripe.Visual.prototype.init.call(this);
 
     // options variables
+    this.id = this.options.id || null;
     this.width = this.options.width || null;
     this.height = this.options.height || null;
     this.size = this.options.size || null;
@@ -1740,7 +1741,7 @@ ripe.ConfiguratorCsr.prototype._onPostConfig = async function(self, config) {
         await this.flushPending(true);
 
         self.loading = false;
-        this.trigger("ready", { id: "configurator_csr" });
+        this.trigger("ready", { id: this.id, origin: "configurator-csr" });
     };
 
     // runs synchronously or asynchronously depending on how the CSR configurator was setup

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -58,7 +58,7 @@ ripe.ConfiguratorCsr.prototype.init = function() {
     ripe.Visual.prototype.init.call(this);
 
     // options variables
-    this.id = this.options.id ?? 0;
+    this.id = this.options.id || 0;
     this.width = this.options.width || null;
     this.height = this.options.height || null;
     this.size = this.options.size || null;

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -58,7 +58,7 @@ ripe.ConfiguratorCsr.prototype.init = function() {
     ripe.Visual.prototype.init.call(this);
 
     // options variables
-    this.id = this.options.id || null;
+    this.id = this.options.id ?? 0;
     this.width = this.options.width || null;
     this.height = this.options.height || null;
     this.size = this.options.size || null;

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -1740,8 +1740,7 @@ ripe.ConfiguratorCsr.prototype._onPostConfig = async function(self, config) {
         await this.flushPending(true);
 
         self.loading = false;
-        this.trigger("ready");
-        this.trigger("post_config", config);
+        this.trigger("ready", { id: "configurator_csr" });
     };
 
     // runs synchronously or asynchronously depending on how the CSR configurator was setup

--- a/src/js/visual/configurator-csr.js
+++ b/src/js/visual/configurator-csr.js
@@ -1741,6 +1741,7 @@ ripe.ConfiguratorCsr.prototype._onPostConfig = async function(self, config) {
 
         self.loading = false;
         this.trigger("ready");
+        this.trigger("post_config", config);
     };
 
     // runs synchronously or asynchronously depending on how the CSR configurator was setup

--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -57,6 +57,7 @@ ripe.ConfiguratorPrc.prototype.constructor = ripe.ConfiguratorPrc;
 ripe.ConfiguratorPrc.prototype.init = function() {
     ripe.Visual.prototype.init.call(this);
 
+    this.id = this.options.id || null;
     this.width = this.options.width || null;
     this.height = this.options.height || null;
     this.format = this.options.format || null;
@@ -1172,7 +1173,7 @@ ripe.ConfiguratorPrc.prototype._updateConfig = async function(animate) {
     // marks the current configurator as ready and triggers
     // the associated ready event to any event listener
     this.ready = true;
-    this.trigger("ready");
+    this.trigger("ready", { id: this.id, origin: "configurator-prc" });
 
     // adds the config visual class indicating that
     // a configuration already exists for the current

--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -57,7 +57,7 @@ ripe.ConfiguratorPrc.prototype.constructor = ripe.ConfiguratorPrc;
 ripe.ConfiguratorPrc.prototype.init = function() {
     ripe.Visual.prototype.init.call(this);
 
-    this.id = this.options.id ?? 0;
+    this.id = this.options.id || 0;
     this.width = this.options.width || null;
     this.height = this.options.height || null;
     this.format = this.options.format || null;

--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -57,7 +57,7 @@ ripe.ConfiguratorPrc.prototype.constructor = ripe.ConfiguratorPrc;
 ripe.ConfiguratorPrc.prototype.init = function() {
     ripe.Visual.prototype.init.call(this);
 
-    this.id = this.options.id || null;
+    this.id = this.options.id ?? 0;
     this.width = this.options.width || null;
     this.height = this.options.height || null;
     this.format = this.options.format || null;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/1098 |
| Decisions | - Add params to `ready` event in configurator csr  and prc, allowing for any loaders to catch this event. This is because `ready` event is triggered in a lot of places and not specific enough to use as a loader bind. |

