### PR TITLE
#479 Support computation of initials config by adding `initialsConfig` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Add `initialsConfig` method - [#479](https://github.com/ripe-tech/ripe-sdk/issues/479)
+* Add `#initialsConfig()` tests - [#479](https://github.com/ripe-tech/ripe-sdk/issues/479)
 
 ### Changed
 

--- a/src/js/base/config.js
+++ b/src/js/base/config.js
@@ -57,7 +57,7 @@ ripe.Ripe.prototype.initialsConfig = function(config, profiles = []) {
     }
 
     const profilesValues = initials.$profiles || {};
-    const alias =  initials.$alias || {};
+    const alias = initials.$alias || {};
 
     const profilesFinal = [];
     baseProfiles.reverse().forEach(profile => {
@@ -67,13 +67,13 @@ ripe.Ripe.prototype.initialsConfig = function(config, profiles = []) {
             const values = profilesValues[p];
             if (!values) return;
 
-            initials = { ...initials, ...values }
+            initials = { ...initials, ...values };
             profilesFinal.push(p);
         });
     });
 
     const initialsRoot = initials.$root || {};
-    initials = {...initials, ...initialsRoot };
+    initials = { ...initials, ...initialsRoot };
 
     initials.profiles = profilesFinal;
 

--- a/src/js/base/config.js
+++ b/src/js/base/config.js
@@ -52,6 +52,9 @@ ripe.Ripe.prototype.hasStrategy = function(strategy) {
  * `profiles` argument is provided those profiles will be also used to compute the
  * initials config.
  *
+ * This method is implements the same logic as `initials_config` in the composition
+ * engine this should be kept in sync with that implementation.
+ *
  * @param {Object} config The model's config.
  * @param {Array} profiles The list of profiles to use.
  * @returns {Object} The computed initials config based on the config profiles and

--- a/src/js/base/config.js
+++ b/src/js/base/config.js
@@ -77,15 +77,29 @@ ripe.Ripe.prototype.initialsConfig = function(config, profiles = []) {
             const values = profilesValues[p];
             if (!values) return;
 
-            initials = { ...initials, ...values };
+            initials = this._initialsUpdate(initials, values);
             profilesFinal.push(p);
         });
     });
 
     const initialsRoot = initials.$root || {};
-    initials = { ...initials, ...initialsRoot };
+    initials = this._initialsUpdate(initials, initialsRoot);
 
     initials.profiles = profilesFinal;
 
     return initials;
+};
+
+/**
+ * Retrieves the updated initials config by merging the initials config values
+ * with other initials config values.
+ *
+ * @param {Object} initials The base initials config values.
+ * @param {Object} values The initials config values to be applied.
+ * @returns {Object} The update initials config.
+ * 
+ * @private
+ */
+ripe.Ripe.prototype._initialsUpdate = function(initials, values) {
+    return { ...initials, ...values };
 };

--- a/src/js/base/config.js
+++ b/src/js/base/config.js
@@ -59,13 +59,14 @@ ripe.Ripe.prototype.hasStrategy = function(strategy) {
  */
 ripe.Ripe.prototype.initialsConfig = function(config, profiles = []) {
     let initials = config.initials || {};
-    const baseProfiles = config.initials && config.initials.profiles ? config.initials.profiles : [];
+    const baseProfiles =
+        config.initials && config.initials.profiles ? config.initials.profiles : [];
 
     const baseProfile = initials.profile || null;
     if (baseProfile && !baseProfiles.includes(baseProfile)) {
         baseProfiles.push(baseProfile);
     }
-    profiles = profiles.concat(baseProfiles); 
+    profiles = profiles.concat(baseProfiles);
 
     const $profiles = initials.$profiles || {};
     const $alias = initials.$alias || {};

--- a/src/js/base/config.js
+++ b/src/js/base/config.js
@@ -52,8 +52,8 @@ ripe.Ripe.prototype.hasStrategy = function(strategy) {
  * `profiles` argument is provided those profiles will be also used to compute the
  * initials config.
  *
- * This method is implements the same logic as `initials_config` in the composition
- * engine this should be kept in sync with that implementation.
+ * This method implements the same logic as `initials_config` in the composition
+ * engine and should be kept in sync with that implementation.
  *
  * @param {Object} config The model's config.
  * @param {Array} profiles The list of profiles to use.

--- a/src/js/base/config.js
+++ b/src/js/base/config.js
@@ -47,6 +47,16 @@ ripe.Ripe.prototype.hasStrategy = function(strategy) {
     return strategies.includes(strategy);
 };
 
+/**
+ * Retrieves the initials config with the specified profiles in the config. If the
+ * `profiles` argument is provided those profiles will be also used to compute the
+ * initials config.
+ *
+ * @param {Object} config The model's config.
+ * @param {Array} profiles The list of profiles to use.
+ * @returns {Object} The computed initials config based on the config profiles and
+ * specified profiles.
+ */
 ripe.Ripe.prototype.initialsConfig = function(config, profiles = []) {
     let initials = config.initials || {};
 

--- a/src/js/base/config.js
+++ b/src/js/base/config.js
@@ -97,7 +97,7 @@ ripe.Ripe.prototype.initialsConfig = function(config, profiles = []) {
  * @param {Object} initials The base initials config values.
  * @param {Object} values The initials config values to be applied.
  * @returns {Object} The update initials config.
- * 
+ *
  * @private
  */
 ripe.Ripe.prototype._initialsUpdate = function(initials, values) {

--- a/src/js/base/config.js
+++ b/src/js/base/config.js
@@ -59,18 +59,19 @@ ripe.Ripe.prototype.hasStrategy = function(strategy) {
  */
 ripe.Ripe.prototype.initialsConfig = function(config, profiles = []) {
     let initials = config.initials || {};
+    const baseProfiles = config.initials && config.initials.profiles ? config.initials.profiles : [];
 
     const baseProfile = initials.profile || null;
-    const baseProfiles = profiles.length > 0 ? profiles : initials.profiles || [];
     if (baseProfile && !baseProfiles.includes(baseProfile)) {
         baseProfiles.push(baseProfile);
     }
+    profiles = profiles.concat(baseProfiles); 
 
     const $profiles = initials.$profiles || {};
     const $alias = initials.$alias || {};
 
     const finalProfiles = [];
-    baseProfiles.reverse().forEach(profile => {
+    profiles.reverse().forEach(profile => {
         const aliasProfiles = $alias[profile] || [];
         aliasProfiles.push(profile);
         aliasProfiles.forEach(aliasProfile => {

--- a/src/js/base/config.js
+++ b/src/js/base/config.js
@@ -46,3 +46,36 @@ ripe.Ripe.prototype.hasStrategy = function(strategy) {
     const strategies = (this.loadedConfig && this.loadedConfig.strategies) || ["prc"];
     return strategies.includes(strategy);
 };
+
+ripe.Ripe.prototype.initialsConfig = function(config) {
+    let initials = config.initials || {};
+
+    const baseProfile = initials.profile || null;
+    const baseProfiles = initials.profiles || [];
+    if (baseProfile && !baseProfiles.includes(baseProfile)) {
+        baseProfiles.push(baseProfile);
+    }
+
+    const profiles = initials.$profiles || {};
+    const alias =  initials.$alias || {};
+
+    const profilesFinal = [];
+    baseProfiles.reverse().forEach(profile => {
+        const aliasProfiles = alias[profile] || [];
+        aliasProfiles.push(profile);
+        aliasProfiles.forEach(p => {
+            const values = profiles[p];
+            if (!values) return;
+
+            initials = { ...initials, ...values }
+            profilesFinal.push(p);
+        });
+    });
+
+    const initialsRoot = initials.$root || {};
+    initials = {...initials, ...initialsRoot };
+
+    initials.profiles = profilesFinal;
+
+    return initials;
+};

--- a/src/js/base/config.js
+++ b/src/js/base/config.js
@@ -47,16 +47,16 @@ ripe.Ripe.prototype.hasStrategy = function(strategy) {
     return strategies.includes(strategy);
 };
 
-ripe.Ripe.prototype.initialsConfig = function(config) {
+ripe.Ripe.prototype.initialsConfig = function(config, profiles = []) {
     let initials = config.initials || {};
 
     const baseProfile = initials.profile || null;
-    const baseProfiles = initials.profiles || [];
+    const baseProfiles = profiles || initials.profiles || [];
     if (baseProfile && !baseProfiles.includes(baseProfile)) {
         baseProfiles.push(baseProfile);
     }
 
-    const profiles = initials.$profiles || {};
+    const profilesValues = initials.$profiles || {};
     const alias =  initials.$alias || {};
 
     const profilesFinal = [];
@@ -64,7 +64,7 @@ ripe.Ripe.prototype.initialsConfig = function(config) {
         const aliasProfiles = alias[profile] || [];
         aliasProfiles.push(profile);
         aliasProfiles.forEach(p => {
-            const values = profiles[p];
+            const values = profilesValues[p];
             if (!values) return;
 
             initials = { ...initials, ...values }

--- a/src/js/base/config.js
+++ b/src/js/base/config.js
@@ -61,31 +61,31 @@ ripe.Ripe.prototype.initialsConfig = function(config, profiles = []) {
     let initials = config.initials || {};
 
     const baseProfile = initials.profile || null;
-    const baseProfiles = profiles || initials.profiles || [];
+    const baseProfiles = profiles.length > 0 ? profiles : initials.profiles || [];
     if (baseProfile && !baseProfiles.includes(baseProfile)) {
         baseProfiles.push(baseProfile);
     }
 
-    const profilesValues = initials.$profiles || {};
-    const alias = initials.$alias || {};
+    const $profiles = initials.$profiles || {};
+    const $alias = initials.$alias || {};
 
-    const profilesFinal = [];
+    const finalProfiles = [];
     baseProfiles.reverse().forEach(profile => {
-        const aliasProfiles = alias[profile] || [];
+        const aliasProfiles = $alias[profile] || [];
         aliasProfiles.push(profile);
-        aliasProfiles.forEach(p => {
-            const values = profilesValues[p];
+        aliasProfiles.forEach(aliasProfile => {
+            const values = $profiles[aliasProfile];
             if (!values) return;
 
             initials = this._initialsUpdate(initials, values);
-            profilesFinal.push(p);
+            finalProfiles.push(aliasProfile);
         });
     });
 
     const initialsRoot = initials.$root || {};
     initials = this._initialsUpdate(initials, initialsRoot);
 
-    initials.profiles = profilesFinal;
+    initials.profiles = finalProfiles;
 
     return initials;
 };

--- a/test/js/base/config.js
+++ b/test/js/base/config.js
@@ -67,79 +67,94 @@ describe("Config", function() {
 
     describe("#initialsConfig()", function() {
         it("should be able to retrieve the initials config with the applied profiles", () => {
-            const config =  {
-                "initials": {
-                    "$profiles": {
-                        "base": {
-                            "frame": "top",
-                            "align": "center",
-                            "image_rotation": 270,
-                            "font_family": "Gold",
-                            "font_spacing": -10,
-                            "rotation": 0,
+            const config = {
+                initials: {
+                    $profiles: {
+                        base: {
+                            frame: "top",
+                            align: "center",
+                            image_rotation: 270,
+                            font_family: "Gold",
+                            font_spacing: -10,
+                            rotation: 0
                         },
-                        "metal_copper": {"font_family": "Copper"},
-                        "metal_gold": {"font_family": "Gold"},
-                        "metal_silver": {"font_family": "Silver"},
-                        "viewport::large": {"viewport": [324, 283, 250, 250]},
-                        "viewport::medium": {"viewport": [349, 308, 200, 200]},
+                        metal_copper: { font_family: "Copper" },
+                        metal_gold: { font_family: "Gold" },
+                        metal_silver: { font_family: "Silver" },
+                        "viewport::large": { viewport: [324, 283, 250, 250] },
+                        "viewport::medium": { viewport: [349, 308, 200, 200] }
                     },
-                    "$alias": {
+                    $alias: {
                         "step::personalization": ["viewport::large"],
-                        "custom_alias_1": ["base", "viewport::medium"],
-                        "custom_alias_2": ["base", "metal_gold", "metal_silver"],
+                        custom_alias_1: ["base", "viewport::medium"],
+                        custom_alias_2: ["base", "metal_gold", "metal_silver"]
                     }
                 }
-            }
-            const instance = new ripe.Ripe("swear", "vyner", { noBundles: true, remoteCalls: false });
+            };
+            const instance = new ripe.Ripe("swear", "vyner", {
+                noBundles: true,
+                remoteCalls: false
+            });
 
             let initialsConfig = instance.initialsConfig(config);
-            assert.strictEqual(initialsConfig["frame"],  undefined);
-            assert.strictEqual(initialsConfig["align"],  undefined);
-            assert.strictEqual(initialsConfig["image_rotation"],  undefined);
-            assert.strictEqual(initialsConfig["font_family"],  undefined);
-            assert.strictEqual(initialsConfig["font_spacing"],  undefined);
-            assert.strictEqual(initialsConfig["rotation"],  undefined);
+            assert.strictEqual(initialsConfig.frame, undefined);
+            assert.strictEqual(initialsConfig.align, undefined);
+            assert.strictEqual(initialsConfig.image_rotation, undefined);
+            assert.strictEqual(initialsConfig.font_family, undefined);
+            assert.strictEqual(initialsConfig.font_spacing, undefined);
+            assert.strictEqual(initialsConfig.rotation, undefined);
 
             initialsConfig = instance.initialsConfig(config, ["base"]);
-            assert.strictEqual(initialsConfig["frame"], "top")
-            assert.strictEqual(initialsConfig["align"], "center")
-            assert.strictEqual(initialsConfig["image_rotation"], 270)
-            assert.strictEqual(initialsConfig["font_family"], "Gold")
-            assert.strictEqual(initialsConfig["font_spacing"], -10)
-            assert.strictEqual(initialsConfig["rotation"], 0)
+            assert.strictEqual(initialsConfig.frame, "top");
+            assert.strictEqual(initialsConfig.align, "center");
+            assert.strictEqual(initialsConfig.image_rotation, 270);
+            assert.strictEqual(initialsConfig.font_family, "Gold");
+            assert.strictEqual(initialsConfig.font_spacing, -10);
+            assert.strictEqual(initialsConfig.rotation, 0);
 
             initialsConfig = instance.initialsConfig(config, ["step::personalization"]);
-            assert.strictEqual(initialsConfig["frame"],  undefined);
-            assert.strictEqual(initialsConfig["align"],  undefined);
-            assert.strictEqual(initialsConfig["image_rotation"],  undefined);
-            assert.strictEqual(initialsConfig["font_family"],  undefined);
-            assert.strictEqual(initialsConfig["font_spacing"],  undefined);
-            assert.strictEqual(initialsConfig["rotation"],  undefined);
-            assert.deepEqual(initialsConfig["viewport"], [324, 283, 250, 250])
-            
-            initialsConfig = instance.initialsConfig(config, ["custom_alias_1", "step::personalization"]);
-            assert.strictEqual(initialsConfig["frame"], "top")
-            assert.strictEqual(initialsConfig["align"], "center")
-            assert.strictEqual(initialsConfig["image_rotation"], 270)
-            assert.strictEqual(initialsConfig["font_family"], "Gold")
-            assert.strictEqual(initialsConfig["font_spacing"], -10)
-            assert.strictEqual(initialsConfig["rotation"], 0)
-            assert.deepEqual(initialsConfig["viewport"], [349, 308, 200, 200])
+            assert.strictEqual(initialsConfig.frame, undefined);
+            assert.strictEqual(initialsConfig.align, undefined);
+            assert.strictEqual(initialsConfig.image_rotation, undefined);
+            assert.strictEqual(initialsConfig.font_family, undefined);
+            assert.strictEqual(initialsConfig.font_spacing, undefined);
+            assert.strictEqual(initialsConfig.rotation, undefined);
+            assert.deepEqual(initialsConfig.viewport, [324, 283, 250, 250]);
+
+            initialsConfig = instance.initialsConfig(config, [
+                "custom_alias_1",
+                "step::personalization"
+            ]);
+            assert.strictEqual(initialsConfig.frame, "top");
+            assert.strictEqual(initialsConfig.align, "center");
+            assert.strictEqual(initialsConfig.image_rotation, 270);
+            assert.strictEqual(initialsConfig.font_family, "Gold");
+            assert.strictEqual(initialsConfig.font_spacing, -10);
+            assert.strictEqual(initialsConfig.rotation, 0);
+            assert.deepEqual(initialsConfig.viewport, [349, 308, 200, 200]);
 
             initialsConfig = instance.initialsConfig(config, ["custom_alias_2"]);
-            assert.strictEqual(initialsConfig["frame"], "top")
-            assert.strictEqual(initialsConfig["align"], "center")
-            assert.strictEqual(initialsConfig["image_rotation"], 270)
-            assert.strictEqual(initialsConfig["font_family"], "Silver")
-            assert.strictEqual(initialsConfig["font_spacing"], -10)
-            assert.strictEqual(initialsConfig["rotation"], 0)
+            assert.strictEqual(initialsConfig.frame, "top");
+            assert.strictEqual(initialsConfig.align, "center");
+            assert.strictEqual(initialsConfig.image_rotation, 270);
+            assert.strictEqual(initialsConfig.font_family, "Silver");
+            assert.strictEqual(initialsConfig.font_spacing, -10);
+            assert.strictEqual(initialsConfig.rotation, 0);
 
-            initialsConfig = instance.initialsConfig(config, ["metal_copper", "metal_silver", "metal_gold"]);            
-            assert.strictEqual(initialsConfig["font_family"], "Copper")    
-    
-            initialsConfig = instance.initialsConfig(config, ["custom_alias_2", "metal_copper", "metal_silver", "metal_gold"]);
-            assert.strictEqual(initialsConfig["font_family"], "Silver")
+            initialsConfig = instance.initialsConfig(config, [
+                "metal_copper",
+                "metal_silver",
+                "metal_gold"
+            ]);
+            assert.strictEqual(initialsConfig.font_family, "Copper");
+
+            initialsConfig = instance.initialsConfig(config, [
+                "custom_alias_2",
+                "metal_copper",
+                "metal_silver",
+                "metal_gold"
+            ]);
+            assert.strictEqual(initialsConfig.font_family, "Silver");
         });
     });
 });

--- a/test/js/base/config.js
+++ b/test/js/base/config.js
@@ -161,8 +161,8 @@ describe("Config", function() {
             const instance = await new ripe.Ripe("swear", "vyner", { noBundles: true });
             await instance.isReady();
 
-            const remote = await instance.getInitialsConfigP();
-            const local = instance.initialsConfig(instance.loadedConfig);
+            let remote = await instance.getInitialsConfigP();
+            let local = instance.initialsConfig(instance.loadedConfig);
             assert.deepEqual(remote.profiles, ["base"]);
             assert.strictEqual(remote.frame, "top");
             assert.strictEqual(remote.align, "center");
@@ -177,6 +177,26 @@ describe("Config", function() {
             assert.strictEqual(remote.font_family, local.font_family);
             assert.strictEqual(remote.font_spacing, local.font_spacing);
             assert.strictEqual(remote.rotation, local.rotation);
+
+
+            remote = await instance.getInitialsConfigP( { profiles: ["step::personalization"] });
+            local = instance.initialsConfig(instance.loadedConfig, ["step::personalization"]);
+            assert.deepEqual(remote.profiles, ["base", "viewport::large"]);
+            assert.strictEqual(remote.frame, "top");
+            assert.strictEqual(remote.align, "center");
+            assert.strictEqual(remote.image_rotation, 270);
+            assert.strictEqual(remote.font_family, "SwearGold");
+            assert.strictEqual(remote.font_spacing, -10);
+            assert.strictEqual(remote.rotation, 0);
+            assert.deepEqual(remote.viewport, [324, 283, 250, 250]);
+            assert.deepEqual(remote.profiles, local.profiles);
+            assert.strictEqual(remote.frame, local.frame);
+            assert.strictEqual(remote.align, local.align);
+            assert.strictEqual(remote.image_rotation, local.image_rotation);
+            assert.strictEqual(remote.font_family, local.font_family);
+            assert.strictEqual(remote.font_spacing, local.font_spacing);
+            assert.strictEqual(remote.rotation, local.rotation);
+            assert.deepEqual(remote.viewport, local.viewport);
         });
     });
 });

--- a/test/js/base/config.js
+++ b/test/js/base/config.js
@@ -178,8 +178,7 @@ describe("Config", function() {
             assert.strictEqual(remote.font_spacing, local.font_spacing);
             assert.strictEqual(remote.rotation, local.rotation);
 
-
-            remote = await instance.getInitialsConfigP( { profiles: ["step::personalization"] });
+            remote = await instance.getInitialsConfigP({ profiles: ["step::personalization"] });
             local = instance.initialsConfig(instance.loadedConfig, ["step::personalization"]);
             assert.deepEqual(remote.profiles, ["base", "viewport::large"]);
             assert.strictEqual(remote.frame, "top");

--- a/test/js/base/config.js
+++ b/test/js/base/config.js
@@ -156,5 +156,27 @@ describe("Config", function() {
             ]);
             assert.strictEqual(initialsConfig.font_family, "Silver");
         });
+
+        it("should be able to match the config of the remote initials config call", async () => {
+            const instance = await new ripe.Ripe("swear", "vyner", { noBundles: true });
+            await instance.isReady();
+
+            const remote = await instance.getInitialsConfigP();
+            const local = instance.initialsConfig(instance.loadedConfig);
+            assert.deepEqual(remote.profiles, ["base"]);
+            assert.strictEqual(remote.frame, "top");
+            assert.strictEqual(remote.align, "center");
+            assert.strictEqual(remote.image_rotation, 270);
+            assert.strictEqual(remote.font_family, "SwearGold");
+            assert.strictEqual(remote.font_spacing, -10);
+            assert.strictEqual(remote.rotation, 0);
+            assert.deepEqual(remote.profiles, local.profiles);
+            assert.strictEqual(remote.frame, local.frame);
+            assert.strictEqual(remote.align, local.align);
+            assert.strictEqual(remote.image_rotation, local.image_rotation);
+            assert.strictEqual(remote.font_family, local.font_family);
+            assert.strictEqual(remote.font_spacing, local.font_spacing);
+            assert.strictEqual(remote.rotation, local.rotation);
+        });
     });
 });

--- a/test/js/base/config.js
+++ b/test/js/base/config.js
@@ -64,4 +64,82 @@ describe("Config", function() {
             assert.strictEqual(instance.hasInitialsRadius(), true);
         });
     });
+
+    describe("#initialsConfig()", function() {
+        it("should be able to retrieve the initials config with the applied profiles", () => {
+            const config =  {
+                "initials": {
+                    "$profiles": {
+                        "base": {
+                            "frame": "top",
+                            "align": "center",
+                            "image_rotation": 270,
+                            "font_family": "Gold",
+                            "font_spacing": -10,
+                            "rotation": 0,
+                        },
+                        "metal_copper": {"font_family": "Copper"},
+                        "metal_gold": {"font_family": "Gold"},
+                        "metal_silver": {"font_family": "Silver"},
+                        "viewport::large": {"viewport": [324, 283, 250, 250]},
+                        "viewport::medium": {"viewport": [349, 308, 200, 200]},
+                    },
+                    "$alias": {
+                        "step::personalization": ["viewport::large"],
+                        "custom_alias_1": ["base", "viewport::medium"],
+                        "custom_alias_2": ["base", "metal_gold", "metal_silver"],
+                    }
+                }
+            }
+            const instance = new ripe.Ripe("swear", "vyner", { noBundles: true, remoteCalls: false });
+
+            let initialsConfig = instance.initialsConfig(config);
+            assert.strictEqual(initialsConfig["frame"],  undefined);
+            assert.strictEqual(initialsConfig["align"],  undefined);
+            assert.strictEqual(initialsConfig["image_rotation"],  undefined);
+            assert.strictEqual(initialsConfig["font_family"],  undefined);
+            assert.strictEqual(initialsConfig["font_spacing"],  undefined);
+            assert.strictEqual(initialsConfig["rotation"],  undefined);
+
+            initialsConfig = instance.initialsConfig(config, ["base"]);
+            assert.strictEqual(initialsConfig["frame"], "top")
+            assert.strictEqual(initialsConfig["align"], "center")
+            assert.strictEqual(initialsConfig["image_rotation"], 270)
+            assert.strictEqual(initialsConfig["font_family"], "Gold")
+            assert.strictEqual(initialsConfig["font_spacing"], -10)
+            assert.strictEqual(initialsConfig["rotation"], 0)
+
+            initialsConfig = instance.initialsConfig(config, ["step::personalization"]);
+            assert.strictEqual(initialsConfig["frame"],  undefined);
+            assert.strictEqual(initialsConfig["align"],  undefined);
+            assert.strictEqual(initialsConfig["image_rotation"],  undefined);
+            assert.strictEqual(initialsConfig["font_family"],  undefined);
+            assert.strictEqual(initialsConfig["font_spacing"],  undefined);
+            assert.strictEqual(initialsConfig["rotation"],  undefined);
+            assert.deepEqual(initialsConfig["viewport"], [324, 283, 250, 250])
+            
+            initialsConfig = instance.initialsConfig(config, ["custom_alias_1", "step::personalization"]);
+            assert.strictEqual(initialsConfig["frame"], "top")
+            assert.strictEqual(initialsConfig["align"], "center")
+            assert.strictEqual(initialsConfig["image_rotation"], 270)
+            assert.strictEqual(initialsConfig["font_family"], "Gold")
+            assert.strictEqual(initialsConfig["font_spacing"], -10)
+            assert.strictEqual(initialsConfig["rotation"], 0)
+            assert.deepEqual(initialsConfig["viewport"], [349, 308, 200, 200])
+
+            initialsConfig = instance.initialsConfig(config, ["custom_alias_2"]);
+            assert.strictEqual(initialsConfig["frame"], "top")
+            assert.strictEqual(initialsConfig["align"], "center")
+            assert.strictEqual(initialsConfig["image_rotation"], 270)
+            assert.strictEqual(initialsConfig["font_family"], "Silver")
+            assert.strictEqual(initialsConfig["font_spacing"], -10)
+            assert.strictEqual(initialsConfig["rotation"], 0)
+
+            initialsConfig = instance.initialsConfig(config, ["metal_copper", "metal_silver", "metal_gold"]);            
+            assert.strictEqual(initialsConfig["font_family"], "Copper")    
+    
+            initialsConfig = instance.initialsConfig(config, ["custom_alias_2", "metal_copper", "metal_silver", "metal_gold"]);
+            assert.strictEqual(initialsConfig["font_family"], "Silver")
+        });
+    });
 });


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue |https://github.com/ripe-tech/ripe-sdk/issues/479 |
| Dependencies | -- |
| Decisions | - Add initialsConfig() method which runs the appy profiles logic locally. It's a implementation that matches the one done here: https://github.com/ripe-tech/ripe-compose/blob/40436c5207b01fdff100e6d2425018feb453c731/src/ripe_compose/util/configurator.py#L2213. The reason it's done is to support a way to compute the initials with the profiles applicated without having to do a remote call<br>- Add `initialsConfig()` tests |
