### PR TITLE
Version: `2.38.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+*
+
+### Changed
+
+*
+
+### Fixed
+
+*
+
+## [2.38.0]
+
+### Added
+
 * Add `id` and `origin` to `ready` event params to distinguish events from configurator prc and csr - [ripe-white/#1098](https://github.com/ripe-tech/ripe-white/issues/1098)
 * Add `initialsConfig` method - [#479](https://github.com/ripe-tech/ripe-sdk/issues/479)
 * Add `#initialsConfig()` tests - [#479](https://github.com/ripe-tech/ripe-sdk/issues/479)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ripe-sdk",
-    "version": "2.37.0",
+    "version": "2.38.0",
     "description": "The public SDK for RIPE Core",
     "keywords": [
         "js",

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -16,7 +16,7 @@ if (
  * The version of the RIPE SDK currently in load, should
  * be in sync with the package information.
  */
-ripe.VERSION = "2.37.0";
+ripe.VERSION = "2.38.0";
 
 /**
  * Object that contains global (static) information to be used by


### PR DESCRIPTION
### Added

* Add `id` and `origin` to `ready` event params to distinguish events from configurator prc and csr - [ripe-white/#1098](https://github.com/ripe-tech/ripe-white/issues/1098)
* Add `initialsConfig` method - [#479](https://github.com/ripe-tech/ripe-sdk/issues/479)
* Add `#initialsConfig()` tests - [#479](https://github.com/ripe-tech/ripe-sdk/issues/479)

### Changed

* Reuse Draco loader instance - [#481](https://github.com/ripe-tech/ripe-sdk/issues/481)
* Removed `draco_decoder.js` dependency - [#481](https://github.com/ripe-tech/ripe-sdk/issues/481)
* Use `initialsConfig()` in CSR - [#479](https://github.com/ripe-tech/ripe-sdk/issues/479)

### Fixed

* Fix meshes compressed with Draco not loading properly - [#481](https://github.com/ripe-tech/ripe-sdk/issues/481)