### PR TITLE
#478 Fix CSR documentation compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ package-lock.json
 /src/python/ripe_demo/static/js/ripe.three.min.js
 /src/python/ripe_demo/static/js/ripe.three.min.js.map
 /src/python/ripe_demo/static/css/ripe.css
+
+/documentation/src/.vuepress
+/documentation/node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Update `initialsConfig()` to match remote logic - [#429](https://github.com/ripe-tech/ripe-sdk/issues/429)
+* Update `.gitignore` to ignore CSR documentation compilation files - [#478](https://github.com/ripe-tech/ripe-sdk/issues/478)
 
 ### Fixed
 
-*
+* Fix div tag outside code block in CSR documentation - [#478](https://github.com/ripe-tech/ripe-sdk/issues/478)
 
 ## [2.39.0] - 2023-02-24
 

--- a/documentation/src/README.md
+++ b/documentation/src/README.md
@@ -34,7 +34,7 @@ window.ripeInstance = new Ripe({
 
 ## Binding a configurator
 
-To provide an interactive product visualization you simply need to pass a <div> element to the method bindConfigurator. Subscribe to the event loaded and you will know when your configurator is loaded.
+To provide an interactive product visualization you simply need to pass a `<div>` element to the method bindConfigurator. Subscribe to the event loaded and you will know when your configurator is loaded.
 
 ```js
 window.ripeInstance.bindConfigurator(


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-sdk/issues/478 |
| Decisions | - Fix div tag outside code block in CSR documentation <br> - Update `.gitignore` to ignore CSR documentation compilation files |
