### PR TITLE
Version: `3.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+*
+
+### Changed
+
+*
+
+### Fixed
+
+*
+
+## [3.0.0]
+
+### Added
+
 * Add `browserify`, `esmify`, `babelify`, `vinyl-buffer` and `vinyl-source-stream` dev dependencies - [#491](https://github.com/ripe-tech/ripe-sdk/issues/491)
 * Support ES Modules - [#491](https://github.com/ripe-tech/ripe-sdk/issues/491)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ripe-sdk",
-    "version": "2.40.0",
+    "version": "3.0.0",
     "description": "The public SDK for RIPE Core",
     "keywords": [
         "js",

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -6,7 +6,7 @@ const ripe = base.ripe;
  * The version of the RIPE SDK currently in load, should
  * be in sync with the package information.
  */
-ripe.VERSION = "2.40.0";
+ripe.VERSION = "3.0.0";
 
 /**
  * Object that contains global (static) information to be used by


### PR DESCRIPTION
### Added

* Add `browserify`, `esmify`, `babelify`, `vinyl-buffer` and `vinyl-source-stream` dev dependencies - [#491](https://github.com/ripe-tech/ripe-sdk/issues/491)
* Support ES Modules - [#491](https://github.com/ripe-tech/ripe-sdk/issues/491)

### Changed

* Upgrade workflows's node engine version
* Reduced import hacks - [#491](https://github.com/ripe-tech/ripe-sdk/issues/491)
* Remove `__VERSION__` references - [#491](https://github.com/ripe-tech/ripe-sdk/issues/491)
* Remove `mark` script - [#491](https://github.com/ripe-tech/ripe-sdk/issues/491)
* Update Three.js version to `150.1` - [#491](https://github.com/ripe-tech/ripe-sdk/issues/491)
* Update `@babel/core` to `7.21.0` - [#491](https://github.com/ripe-tech/ripe-sdk/issues/491)
* Removed unused `gulp-babel`, `gulp-concat` and `gulp-replace` dev dependencies - [#491](https://github.com/ripe-tech/ripe-sdk/issues/491)

### Fixed

* Fix package not loading Three.js - [#491](https://github.com/ripe-tech/ripe-sdk/issues/491)
* Fix build not including all code when generating the bundle - [#491](https://github.com/ripe-tech/ripe-sdk/issues/491)