### PR TITLE
#511 Configurator ignoring size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Fixed configurator ignoring size even with passing `useDefaultSize` with `false` - [#511](https://github.com/ripe-tech/ripe-sdk/issues/511)
 
 ## [3.0.0] - 2023-03-30
 

--- a/src/js/visual/configurator-prc.js
+++ b/src/js/visual/configurator-prc.js
@@ -70,7 +70,7 @@ ripe.ConfiguratorPrc.prototype.init = function() {
                 ? undefined
                 : !this.noMasks
             : this.options.useMasks;
-    this.useDefaultSize = this.options.useDefaultSize || true;
+    this.useDefaultSize = this.options.useDefaultSize === undefined ? true : this.options.useDefaultSize;
     this.view = this.options.view || "side";
     this.position = this.options.position || 0;
     this.configAnimate =


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-sdk/issues/511|
| Decisions | There is a boolean to force the sdk to use the `width` and  `height` to be used on the rendering call `useDefaultSize`. However that variable would always have a `true` value regardless of what was sent.|
