### PR TITLE
version: 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+*
+
+### Changed
+
+*
+
+### Fixed
+
+*
+
+## [3.0.1] - 2023-05-19
+
+### Added
+
 * Added `sku` and `domain` fields to import order - [ripe-core/#4798](https://github.com/ripe-tech/ripe-core/issues/4798)
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ripe-sdk",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "description": "The public SDK for RIPE Core",
     "keywords": [
         "js",

--- a/src/js/base/ripe.js
+++ b/src/js/base/ripe.js
@@ -6,7 +6,7 @@ const ripe = base.ripe;
  * The version of the RIPE SDK currently in load, should
  * be in sync with the package information.
  */
-ripe.VERSION = "3.0.0";
+ripe.VERSION = "3.0.1";
 
 /**
  * Object that contains global (static) information to be used by


### PR DESCRIPTION
### Added

* Added `sku` and `domain` fields to import order - [ripe-core/#4798](https://github.com/ripe-tech/ripe-core/issues/4798)

### Changed

* Remove Travis CI - [products/#97](https://github.com/ripe-tech/products/issues/97https://github.com/ripe-tech/products/issues/97)

### Fixed

* Fixed configurator ignoring size even with passing `useDefaultSize` with `false` - [#511](https://github.com/ripe-tech/ripe-sdk/issues/511)