### PR TITLE
Replace API test provider from `httpbin` to `postman-echo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-*
+* Change http api testing provider from `httpbin` to `postman-echo`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Change http api testing provider from `httpbin` to `postman-echo`
+* Change API testing provider from `httpbin` to `postman-echo`
 
 ### Fixed
 

--- a/test/js/base/api.js
+++ b/test/js/base/api.js
@@ -43,7 +43,7 @@ describe("RipeAPI", function() {
                 }
             };
             await new Promise((resolve, reject) => {
-                remote._cacheURL("https://httpbin.org/status/403", options, () => resolve());
+                remote._cacheURL("https://postman-echo.com/status/403", options, () => resolve());
             });
             assert.strictEqual(options.retries, 0);
             assert.strictEqual(options.dummy, 1);
@@ -56,7 +56,7 @@ describe("RipeAPI", function() {
                 }
             };
             await new Promise((resolve, reject) => {
-                remote._cacheURL("https://httpbin.org/status/403", options, () => resolve());
+                remote._cacheURL("https://postman-echo.com/status/403", options, () => resolve());
             });
             assert.strictEqual(options.retries, 0);
             assert.strictEqual(options.dummy, 2);
@@ -73,7 +73,7 @@ describe("RipeAPI", function() {
                 }
             };
             await new Promise((resolve, reject) => {
-                remote._cacheURL("https://httpbin.org/status/200", options, () => resolve());
+                remote._cacheURL("https://postman-echo.com/status/200", options, () => resolve());
             });
             assert.strictEqual(options.retries, 2);
             assert.strictEqual(options.dummy, 3);


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Tests are failing fairly frequently when running `_authCallback` this is because the API testing provider `https://httpbin.org/` is not very stable/reliable. We could improve this by switching to a more reliable alternative. |
| Decisions | - Change `httpbin` to `postman-echo` as a more "production-ready" and mature alternative. |
