### PR TITLE
feat: add compose url option to the ripe-sdk demo

### DIFF
--- a/src/python/ripe_demo/controllers/base.py
+++ b/src/python/ripe_demo/controllers/base.py
@@ -17,6 +17,7 @@ class BaseController(appier.Controller):
         return self.template(
             "simple.html.tpl",
             url=self.field("url"),
+            compose_url=self.field("compose_url"),
             brand=self.field("brand"),
             model=self.field("model"),
             variant=self.field("variant"),

--- a/src/python/ripe_demo/static/js/main.js
+++ b/src/python/ripe_demo/static/js/main.js
@@ -12,6 +12,7 @@ window.onload = function() {
     const element = document.getElementById("configurator-prc");
     const _body = document.querySelector("body");
     const url = _body.dataset.url || "https://sandbox.platforme.com/api/";
+    const composeUrl = _body.dataset.compose_url || null;
     const brand = _body.dataset.brand || "dummy";
     const model = _body.dataset.model || "cube";
     const variant = _body.dataset.variant || "";
@@ -35,6 +36,7 @@ window.onload = function() {
         version: version,
         format: format,
         url: url,
+        composeUrl: composeUrl,
         currency: currency,
         country: country,
         guess: guess,

--- a/src/python/ripe_demo/templates/partials/layout.html.tpl
+++ b/src/python/ripe_demo/templates/partials/layout.html.tpl
@@ -22,7 +22,7 @@
             <title>{{ title }}{% block title %}RIPE SDK Demo{% endblock %}</title>
         {% endblock %}
     </head>
-    <body class="{% block body_class %}ux wait-load{% endblock %}" data-url="{{ url|default('', True) }}"
+    <body class="{% block body_class %}ux wait-load{% endblock %}" data-url="{{ url|default('', True) }}" data-compose_url="{{ compose_url|default('', True) }}"
              data-brand="{{ brand|default('', True) }}" data-model="{{ model|default('', True) }}"
              data-variant="{{ variant|default('', True) }}" data-version="{{ version|default('', True) }}"
              data-country="{{ country|default('', True) }}" data-currency="{{ currency|default('', True) }}"


### PR DESCRIPTION
### Issue
- https://github.com/ripe-tech/products/issues/132

### Dependencies
- https://github.com/ripe-tech/ripe-sdk/pull/517

### Decisions
- added `compose_url` GET parameter to the RIPE SDK demo page

### Screenshots
- None
